### PR TITLE
Footer (#16)

### DIFF
--- a/app/[locale]/(public)/images/index.ts
+++ b/app/[locale]/(public)/images/index.ts
@@ -1,1 +1,2 @@
 export { default as logoFull } from "./icons/Logo-paddle-text.svg";
+export { default as logoSmall } from "./icons/Logo-paddle.svg";

--- a/app/[locale]/_components/footer.tsx
+++ b/app/[locale]/_components/footer.tsx
@@ -1,67 +1,79 @@
+import Image from "next/image";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
+import { logoSmall } from "@app/[locale]/(public)/images";
+
 import { FOOTER_SECTIONS } from "@/shared/globals";
+import { classNames } from "@/shared/styles";
 
 export default async function Footer() {
-  const t = await getTranslations("Footer");
+  const t = await getTranslations("footer");
 
   return (
     <footer
       className="border-border-default bg-bg-primary text-text-secondary border-t"
       role="contentinfo"
     >
-      <div className="mx-auto grid max-w-7xl gap-8 px-4 py-10 sm:grid-cols-2 sm:px-6 lg:grid-cols-4 lg:px-8">
-        {FOOTER_SECTIONS.map((section) => (
-          <nav aria-labelledby={`footer-${section.id}`} key={section.id}>
-            <h2
-              className="text-xs font-semibold tracking-wide uppercase"
-              id={`footer-${section.id}`}
+      <div className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-2">
+        <div className="flex flex-wrap items-start gap-x-24 gap-y-8">
+          <div className="shrink-0 basis-full sm:basis-auto">
+            <Image alt="logo small" height={40} src={logoSmall} width={40} />
+          </div>
+
+          {FOOTER_SECTIONS.map((section) => (
+            <nav
+              aria-labelledby={`footer-${section.id}`}
+              className="shrink-0"
+              key={section.id}
             >
-              {t(section.titleKey)}
-            </h2>
-            <ul className="mt-3 space-y-2 text-sm">
-              {section.links.map((link) => (
-                <li key={link.labelKey}>
-                  {link.external ? (
-                    <a
-                      className="underline-offset-2 hover:underline"
-                      href={link.href}
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      {t(link.labelKey)}
-                    </a>
-                  ) : (
-                    <Link
-                      className="underline-offset-2 hover:underline"
-                      href={link.href}
-                    >
-                      {t(link.labelKey)}
-                    </Link>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </nav>
-        ))}
+              <h2
+                className="text-xs font-semibold tracking-wide uppercase"
+                id={`footer-${section.id}`}
+              >
+                {t(section.titleKey)}
+              </h2>
+              <ul className="mt-3 space-y-2 text-sm">
+                {section.links.map((link) => (
+                  <li key={link.labelKey}>
+                    {link.external ? (
+                      <a
+                        className="underline-offset-2 hover:underline"
+                        href={link.href}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        {t(link.labelKey)}
+                      </a>
+                    ) : (
+                      <Link
+                        className="underline-offset-2 hover:underline"
+                        href={link.href}
+                      >
+                        {t(link.labelKey)}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          ))}
+        </div>
       </div>
 
-      <div className="border-border-default mx-auto flex max-w-7xl flex-col gap-3 border-t px-4 pt-6 pb-10 text-xs sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
-        <div className="flex items-center gap-2">
-          <span
-            aria-hidden
-            className="bg-accent-blue inline-block h-3.5 w-3.5 rounded-full"
-          />
-          <span className="font-medium">PingPong</span>
-        </div>
+      <div
+        className={classNames(
+          "border-border-default mx-auto max-w-7xl border-t px-4 pt-6",
+          "pb-10 text-xs sm:flex sm:items-center sm:justify-between sm:px-6 lg:px-8",
+        )}
+      >
         <p>
           {t("legal.copyright", {
             company: "LoneStarDev",
             year: new Date().getFullYear(),
           })}
         </p>
-        <p>
+        <p className="mt-3 sm:mt-0">
           {t("legal.build", {
             version: process.env.NEXT_PUBLIC_BUILD ?? "1.0.0",
           })}

--- a/app/[locale]/_components/footer.tsx
+++ b/app/[locale]/_components/footer.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+
+import { FOOTER_SECTIONS } from "@/shared/globals";
+
+export default async function Footer() {
+  const t = await getTranslations("Footer");
+
+  return (
+    <footer
+      className="border-border-default bg-bg-primary text-text-secondary border-t"
+      role="contentinfo"
+    >
+      <div className="mx-auto grid max-w-7xl gap-8 px-4 py-10 sm:grid-cols-2 sm:px-6 lg:grid-cols-4 lg:px-8">
+        {FOOTER_SECTIONS.map((section) => (
+          <nav aria-labelledby={`footer-${section.id}`} key={section.id}>
+            <h2
+              className="text-xs font-semibold tracking-wide uppercase"
+              id={`footer-${section.id}`}
+            >
+              {t(section.titleKey)}
+            </h2>
+            <ul className="mt-3 space-y-2 text-sm">
+              {section.links.map((link) => (
+                <li key={link.labelKey}>
+                  {link.external ? (
+                    <a
+                      className="underline-offset-2 hover:underline"
+                      href={link.href}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      {t(link.labelKey)}
+                    </a>
+                  ) : (
+                    <Link
+                      className="underline-offset-2 hover:underline"
+                      href={link.href}
+                    >
+                      {t(link.labelKey)}
+                    </Link>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </nav>
+        ))}
+      </div>
+
+      <div className="border-border-default mx-auto flex max-w-7xl flex-col gap-3 border-t px-4 pt-6 pb-10 text-xs sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className="bg-accent-blue inline-block h-3.5 w-3.5 rounded-full"
+          />
+          <span className="font-medium">PingPong</span>
+        </div>
+        <p>
+          {t("legal.copyright", {
+            company: "LoneStarDev",
+            year: new Date().getFullYear(),
+          })}
+        </p>
+        <p>
+          {t("legal.build", {
+            version: process.env.NEXT_PUBLIC_BUILD ?? "1.0.0",
+          })}
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/app/[locale]/_components/index.ts
+++ b/app/[locale]/_components/index.ts
@@ -1,2 +1,3 @@
+export { default as Footer } from "./footer";
 export { default as Header } from "./header";
 export { LanguageSwitch } from "./language-switch";

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { getMessages, setRequestLocale } from "next-intl/server";
 
-import { Header } from "@app/[locale]/_components";
+import { Footer, Header } from "@app/[locale]/_components";
 
 import "@/shared/styles/globals.css";
 
@@ -35,6 +35,7 @@ export default async function LocaleLayout({
         <NextIntlClientProvider locale={locale} messages={messages}>
           <Header />
           {children}
+          <Footer />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,7 +105,7 @@ export default tseslint.config(
 
       "perfectionist/sort-imports": "off",
       "react-compiler/react-compiler": "error",
-      "simple-import-sort/exports": "error",
+      "simple-import-sort/exports": "off",
       "simple-import-sort/imports": [
         "error",
         {

--- a/shared/globals/globals.ts
+++ b/shared/globals/globals.ts
@@ -11,9 +11,9 @@ export const FOOTER_SECTIONS: Section[] = [
   {
     id: "product",
     links: [
-      { href: "/#how-it-works", labelKey: "sections.product.links.howItWorks" },
-      { href: "/#clients", labelKey: "sections.product.links.clients" },
-      { href: "/pricing", labelKey: "sections.product.links.pricing" },
+      { href: "", labelKey: "sections.product.links.howItWorks" },
+      { href: "", labelKey: "sections.product.links.clients" },
+      { href: "", labelKey: "sections.product.links.pricing" },
     ],
     titleKey: "sections.product.title",
   },

--- a/shared/globals/globals.ts
+++ b/shared/globals/globals.ts
@@ -1,5 +1,77 @@
+import type { Section } from "@/shared/types";
+import type { Language } from "@/shared/types";
+
 export const LANGUAGES = [
   { code: "en", name: "English" },
   { code: "ru", name: "Русский" },
   { code: "be", name: "Беларуская" },
+] as const satisfies readonly Language[];
+
+export const FOOTER_SECTIONS: Section[] = [
+  {
+    id: "product",
+    links: [
+      { href: "/#how-it-works", labelKey: "sections.product.links.howItWorks" },
+      { href: "/#clients", labelKey: "sections.product.links.clients" },
+      { href: "/pricing", labelKey: "sections.product.links.pricing" },
+    ],
+    titleKey: "sections.product.title",
+  },
+  {
+    id: "team",
+    links: [
+      {
+        external: true,
+        href: "https://github.com/dariadrozdova",
+        labelKey: "sections.team.links.daria",
+      },
+      {
+        external: true,
+        href: "https://github.com/whowouldwin",
+        labelKey: "sections.team.links.valeria",
+      },
+      {
+        external: true,
+        href: "https://github.com/aashapovalov",
+        labelKey: "sections.team.links.aleksei",
+      },
+    ],
+    titleKey: "sections.team.title",
+  },
+  {
+    id: "inspired",
+    links: [
+      {
+        external: true,
+        href: "https://rs.school",
+        labelKey: "sections.inspired.links.rsSchool",
+      },
+      {
+        external: true,
+        href: "https://rs.school/courses/reactjs",
+        labelKey: "sections.inspired.links.reactCourse",
+      },
+      {
+        external: true,
+        href: "https://github.com/andron13",
+        labelKey: "sections.inspired.links.mentor",
+      },
+    ],
+    titleKey: "sections.inspired.title",
+  },
+  {
+    id: "support",
+    links: [
+      {
+        external: true,
+        href: "https://boosty.to/rsschool",
+        labelKey: "sections.support.links.boosty",
+      },
+      {
+        href: "https://opencollective.com/rsschool",
+        labelKey: "sections.support.links.opencollective",
+      },
+    ],
+    titleKey: "sections.support.title",
+  },
 ];

--- a/shared/globals/index.ts
+++ b/shared/globals/index.ts
@@ -1,1 +1,1 @@
-export { LANGUAGES } from "./globals";
+export { FOOTER_SECTIONS, LANGUAGES } from "./globals";

--- a/shared/lib/i18n/messages/be/footer.json
+++ b/shared/lib/i18n/messages/be/footer.json
@@ -20,15 +20,15 @@
       "title": "Нас натхнілі",
       "links": {
         "rsSchool": "RS School",
-        "reactCourse": "Курс па React 2025",
+        "reactCourse": "Курс React (RS School)",
         "mentor": "Ментар (andron13)"
       }
     },
-    "connect": {
-      "title": "Кантакты",
+    "support": {
+      "title": "Падтрымаць RS School",
       "links": {
-        "github": "GitHub",
-        "contact": "Звязацца з намі"
+        "boosty": "Падпісацца на Boosty",
+        "opencollective": "Ахвяраваць на Open Collective"
       }
     }
   },

--- a/shared/lib/i18n/messages/be/footer.json
+++ b/shared/lib/i18n/messages/be/footer.json
@@ -1,0 +1,39 @@
+{
+  "sections": {
+    "product": {
+      "title": "Прадукт",
+      "links": {
+        "howItWorks": "Як гэта працуе",
+        "clients": "Нашы кліенты",
+        "pricing": "Кошты"
+      }
+    },
+    "team": {
+      "title": "Каманда LoneStarDev",
+      "links": {
+        "daria": "Дар'я Ткачэнка",
+        "valeria": "Валерыя Бяссонава",
+        "aleksei": "Аляксей Шапавалаў"
+      }
+    },
+    "inspired": {
+      "title": "Нас натхнілі",
+      "links": {
+        "rsSchool": "RS School",
+        "reactCourse": "Курс па React 2025",
+        "mentor": "Ментар (andron13)"
+      }
+    },
+    "connect": {
+      "title": "Кантакты",
+      "links": {
+        "github": "GitHub",
+        "contact": "Звязацца з намі"
+      }
+    }
+  },
+  "legal": {
+    "copyright": "© {year} {company}. Усе правы абаронены.",
+    "build": "Зборка v{version}"
+  }
+}

--- a/shared/lib/i18n/messages/en/footer.json
+++ b/shared/lib/i18n/messages/en/footer.json
@@ -24,7 +24,7 @@
         "mentor": "Mentor (andron13)"
       }
     },
-    "connect": {
+    "support": {
       "title": "Connect",
       "links": {
         "github": "GitHub",

--- a/shared/lib/i18n/messages/en/footer.json
+++ b/shared/lib/i18n/messages/en/footer.json
@@ -11,8 +11,8 @@
     "team": {
       "title": "LoneStarDev Team",
       "links": {
-        "daria": "Daria Drozdova",
-        "valeria": "Valeria Bessonava",
+        "daria": "Daria Tkachenko",
+        "valeria": "Valeria Bessonova",
         "aleksei": "Aleksei Shapovalov"
       }
     },
@@ -20,15 +20,15 @@
       "title": "Inspired by",
       "links": {
         "rsSchool": "RS School",
-        "reactCourse": "React course 2025",
+        "reactCourse": "React Course (RS School)",
         "mentor": "Mentor (andron13)"
       }
     },
     "support": {
-      "title": "Connect",
+      "title": "Support RS School",
       "links": {
-        "github": "GitHub",
-        "contact": "Contact Us"
+        "boosty": "Subscribe on Boosty",
+        "opencollective": "Donate on Open Collective"
       }
     }
   },

--- a/shared/lib/i18n/messages/en/footer.json
+++ b/shared/lib/i18n/messages/en/footer.json
@@ -1,0 +1,39 @@
+{
+  "sections": {
+    "product": {
+      "title": "Product",
+      "links": {
+        "howItWorks": "How it works",
+        "clients": "Our clients",
+        "pricing": "Pricing"
+      }
+    },
+    "team": {
+      "title": "LoneStarDev Team",
+      "links": {
+        "daria": "Daria Drozdova",
+        "valeria": "Valeria Bessonava",
+        "aleksei": "Aleksei Shapovalov"
+      }
+    },
+    "inspired": {
+      "title": "Inspired by",
+      "links": {
+        "rsSchool": "RS School",
+        "reactCourse": "React course 2025",
+        "mentor": "Mentor (andron13)"
+      }
+    },
+    "connect": {
+      "title": "Connect",
+      "links": {
+        "github": "GitHub",
+        "contact": "Contact Us"
+      }
+    }
+  },
+  "legal": {
+    "copyright": "© {year} {company}. All rights reserved.",
+    "build": "Build v{version}"
+  }
+}

--- a/shared/lib/i18n/messages/ru/footer.json
+++ b/shared/lib/i18n/messages/ru/footer.json
@@ -20,15 +20,15 @@
       "title": "Нас вдохновили",
       "links": {
         "rsSchool": "RS School",
-        "reactCourse": "Курс React 2025",
+        "reactCourse": "Курс React (RS School)",
         "mentor": "Ментор (andron13)"
       }
     },
-    "connect": {
-      "title": "Контакты",
+    "support": {
+      "title": "Поддержать RS School",
       "links": {
-        "github": "GitHub",
-        "contact": "Связаться с нами"
+        "boosty": "Подписаться на Boosty",
+        "opencollective": "Пожертвовать на Open Collective"
       }
     }
   },

--- a/shared/lib/i18n/messages/ru/footer.json
+++ b/shared/lib/i18n/messages/ru/footer.json
@@ -1,0 +1,39 @@
+{
+  "sections": {
+    "product": {
+      "title": "Продукт",
+      "links": {
+        "howItWorks": "Как это работает",
+        "clients": "Наши клиенты",
+        "pricing": "Цены"
+      }
+    },
+    "team": {
+      "title": "Команда LoneStarDev",
+      "links": {
+        "daria": "Дарья Ткаченко",
+        "valeria": "Валерия Бессонова",
+        "aleksei": "Алексей Шаповалов"
+      }
+    },
+    "inspired": {
+      "title": "Нас вдохновили",
+      "links": {
+        "rsSchool": "RS School",
+        "reactCourse": "Курс React 2025",
+        "mentor": "Ментор (andron13)"
+      }
+    },
+    "connect": {
+      "title": "Контакты",
+      "links": {
+        "github": "GitHub",
+        "contact": "Связаться с нами"
+      }
+    }
+  },
+  "legal": {
+    "copyright": "© {year} {company}. Все права защищены.",
+    "build": "Сборка v{version}"
+  }
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,1 +1,1 @@
-export type { Language } from "./types";
+export type { Language, Section } from "./types";

--- a/shared/types/types.ts
+++ b/shared/types/types.ts
@@ -1,3 +1,16 @@
-import { LANGUAGES } from "@/shared/globals";
+export interface Language {
+  code: "be" | "en" | "ru";
+  name: string;
+}
 
-export type Language = (typeof LANGUAGES)[0];
+export interface LinkItem {
+  external?: boolean;
+  href: string;
+  labelKey: string;
+}
+
+export interface Section {
+  id: string;
+  links: LinkItem[];
+  titleKey: string;
+}


### PR DESCRIPTION

<img width="1298" height="322" alt="Screenshot 2025-09-07 at 10 26 00" src="https://github.com/user-attachments/assets/748b9e8d-ddac-4efb-9389-bae3a46a6445" />

## Summary
Server-side `<Footer />` integrated into the root layout. Brand column appears first, followed by four content sections. Uses flex-based row with content-sized columns and equal horizontal gaps. Fully localized and accessible.

## Changes
- Add `Footer` (server component) using `next-intl` (`getTranslations('footer')`).
- Top row: `flex flex-wrap gap-x-24 gap-y-8` for clean, equal gaps.
- Brand column (logo image) first; sections from `FOOTER_SECTIONS` variable.
- External links: `target="_blank" rel="noopener noreferrer"`.
- Bottom bar: localized copyright + build.

## i18n
- Added/updated:
  - `messages/en/Footer.json`
  - `messages/ru/Footer.json`
  - `messages/be/Footer.json`