### PR TITLE
Header for protected zone (#26)

### DIFF
--- a/app/[locale]/(protected)/_components/index.ts
+++ b/app/[locale]/(protected)/_components/index.ts
@@ -1,0 +1,1 @@
+export { default as StickyHeaderGrid } from "./sticky-header-grid";

--- a/app/[locale]/(protected)/_components/left-header-group.tsx
+++ b/app/[locale]/(protected)/_components/left-header-group.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 
+import { useTranslations } from "use-intl";
+
 import { MethodSwitch } from "@app/[locale]/(protected)/_components/method-switch";
 
 import { TABS } from "@/shared/globals";
@@ -9,7 +11,7 @@ import { classNames } from "@/shared/styles";
 
 export default function LeftHeaderGroup() {
   const [activeTab, setActiveTab] = useState<string>(TABS[0]);
-
+  const t = useTranslations("protected-header");
   return (
     <>
       <div className="col-start-1 row-start-1 px-6 pt-8 text-base">
@@ -20,7 +22,7 @@ export default function LeftHeaderGroup() {
             placeholder="https://api.example.com/path..."
           />
           <button className="bg-accent-blue border-accent-blue h-full w-28 rounded-r-md border px-3 py-2 text-sm font-medium text-white">
-            Send
+            {t("protected-header.sendButton")}
           </button>
         </div>
       </div>

--- a/app/[locale]/(protected)/_components/left-header-group.tsx
+++ b/app/[locale]/(protected)/_components/left-header-group.tsx
@@ -33,7 +33,7 @@ export function LeftHeaderGroup() {
           <button
             className={classNames(
               "bg-accent-blue border-accent-blue h-full w-28 rounded-r-md border",
-              "px-3 py-2 text-sm font-medium text-white hover:brightness-110",
+              "cursor-pointer px-3 py-2 text-sm font-medium text-white hover:brightness-110",
             )}
           >
             {t("protected-header.sendButton")}
@@ -54,9 +54,9 @@ export function LeftHeaderGroup() {
                 aria-selected={isActive}
                 className={classNames(
                   "text-text-secondary mb-1 font-bold transition-colors focus-visible:outline",
-                  "hover:text-text-primary",
+                  "hover:text-text-primary cursor-pointer",
                   isActive &&
-                    "decoration-accent-blue font-bold underline decoration-2 underline-offset-8",
+                    "decoration-accent-blue cursor-default font-bold underline decoration-2 underline-offset-8",
                 )}
                 key={key}
                 onClick={() => setActiveTab(key)}

--- a/app/[locale]/(protected)/_components/left-header-group.tsx
+++ b/app/[locale]/(protected)/_components/left-header-group.tsx
@@ -9,14 +9,13 @@ import { classNames } from "@/shared/styles";
 
 export function LeftHeaderGroup() {
   const t = useTranslations("protected-header");
-  const tr = useTranslations("tabs");
 
   const tabs = [
-    { key: "headers", label: tr("headers") },
-    { key: "body", label: tr("body") },
-    { key: "variables", label: tr("variables") },
-    { key: "codegen", label: tr("codegen") },
-    { key: "requestHistory", label: tr("requestHistory") },
+    { key: "headers", label: t("tabs.headers") },
+    { key: "body", label: t("tabs.body") },
+    { key: "variables", label: t("tabs.variables") },
+    { key: "codegen", label: t("tabs.codegen") },
+    { key: "requestHistory", label: t("tabs.requestHistory") },
   ];
 
   const [activeTab, setActiveTab] = useState<string>(tabs[0].key);
@@ -33,10 +32,10 @@ export function LeftHeaderGroup() {
           <button
             className={classNames(
               "bg-accent-blue border-accent-blue h-full w-28 rounded-r-md border",
-              "cursor-pointer px-3 py-2 text-sm font-medium text-white hover:brightness-110",
+              "px-3 py-2 text-sm font-medium text-white hover:brightness-110",
             )}
           >
-            {t("protected-header.sendButton")}
+            {t("sendButton")}
           </button>
         </div>
       </div>
@@ -47,22 +46,22 @@ export function LeftHeaderGroup() {
           className="flex flex-wrap gap-8"
           role="tablist"
         >
-          {tabs.map(({ key }) => {
+          {tabs.map(({ key, label }) => {
             const isActive = activeTab === key;
             return (
               <button
                 aria-selected={isActive}
                 className={classNames(
                   "text-text-secondary mb-1 font-bold transition-colors focus-visible:outline",
-                  "hover:text-text-primary cursor-pointer",
+                  "hover:text-text-primary",
                   isActive &&
-                    "decoration-accent-blue cursor-default font-bold underline decoration-2 underline-offset-8",
+                    "decoration-accent-blue font-bold underline decoration-2 underline-offset-8",
                 )}
                 key={key}
                 onClick={() => setActiveTab(key)}
                 role="tab"
               >
-                {t(`tabs.${key}`)}
+                {label}
               </button>
             );
           })}

--- a/app/[locale]/(protected)/_components/left-header-group.tsx
+++ b/app/[locale]/(protected)/_components/left-header-group.tsx
@@ -7,7 +7,7 @@ import { MethodSwitch } from "@app/[locale]/(protected)/_components/method-switc
 
 import { classNames } from "@/shared/styles";
 
-export default function LeftHeaderGroup() {
+export function LeftHeaderGroup() {
   const t = useTranslations("protected-header");
   const tr = useTranslations("tabs");
 
@@ -30,7 +30,12 @@ export default function LeftHeaderGroup() {
             className="bg-bg-secondary border-border-default h-full w-full border border-x-0 px-3 text-sm"
             placeholder="https://api.example.com/path..."
           />
-          <button className="bg-accent-blue border-accent-blue h-full w-28 rounded-r-md border px-3 py-2 text-sm font-medium text-white">
+          <button
+            className={classNames(
+              "bg-accent-blue border-accent-blue h-full w-28 rounded-r-md border",
+              "px-3 py-2 text-sm font-medium text-white hover:brightness-110",
+            )}
+          >
             {t("protected-header.sendButton")}
           </button>
         </div>
@@ -49,6 +54,7 @@ export default function LeftHeaderGroup() {
                 aria-selected={isActive}
                 className={classNames(
                   "text-text-secondary mb-1 font-bold transition-colors focus-visible:outline",
+                  "hover:text-text-primary",
                   isActive &&
                     "decoration-accent-blue font-bold underline decoration-2 underline-offset-8",
                 )}

--- a/app/[locale]/(protected)/_components/left-header-group.tsx
+++ b/app/[locale]/(protected)/_components/left-header-group.tsx
@@ -1,17 +1,26 @@
 "use client";
 
 import { useState } from "react";
-
-import { useTranslations } from "use-intl";
+import { useTranslations } from "next-intl";
 
 import { MethodSwitch } from "@app/[locale]/(protected)/_components/method-switch";
 
-import { TABS } from "@/shared/globals";
 import { classNames } from "@/shared/styles";
 
 export default function LeftHeaderGroup() {
-  const [activeTab, setActiveTab] = useState<string>(TABS[0]);
   const t = useTranslations("protected-header");
+  const tr = useTranslations("tabs");
+
+  const tabs = [
+    { key: "headers", label: tr("headers") },
+    { key: "body", label: tr("body") },
+    { key: "variables", label: tr("variables") },
+    { key: "codegen", label: tr("codegen") },
+    { key: "requestHistory", label: tr("requestHistory") },
+  ];
+
+  const [activeTab, setActiveTab] = useState<string>(tabs[0].key);
+
   return (
     <>
       <div className="col-start-1 row-start-1 px-6 pt-8 text-base">
@@ -26,28 +35,28 @@ export default function LeftHeaderGroup() {
           </button>
         </div>
       </div>
+
       <div className="col-start-1 row-start-2 flex items-end px-6 pb-0 text-sm">
         <div
           aria-orientation="horizontal"
           className="flex flex-wrap gap-8"
           role="tablist"
         >
-          {TABS.map((tabOption) => {
-            const isActive = activeTab === tabOption;
+          {tabs.map(({ key }) => {
+            const isActive = activeTab === key;
             return (
               <button
                 aria-selected={isActive}
                 className={classNames(
                   "text-text-secondary mb-1 font-bold transition-colors focus-visible:outline",
-                  isActive
-                    ? "decoration-accent-blue font-bold underline decoration-2 underline-offset-8"
-                    : "",
+                  isActive &&
+                    "decoration-accent-blue font-bold underline decoration-2 underline-offset-8",
                 )}
-                key={tabOption}
-                onClick={() => setActiveTab(tabOption)}
+                key={key}
+                onClick={() => setActiveTab(key)}
                 role="tab"
               >
-                {tabOption}
+                {t(`tabs.${key}`)}
               </button>
             );
           })}

--- a/app/[locale]/(protected)/_components/left-header-group.tsx
+++ b/app/[locale]/(protected)/_components/left-header-group.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+
+import { MethodSwitch } from "@app/[locale]/(protected)/_components/method-switch";
+
+import { TABS } from "@/shared/globals";
+import { classNames } from "@/shared/styles";
+
+export default function LeftHeaderGroup() {
+  const [activeTab, setActiveTab] = useState<string>(TABS[0]);
+
+  return (
+    <>
+      <div className="col-start-1 row-start-1 px-6 pt-8 text-base">
+        <div className="flex h-9 w-full items-center">
+          <MethodSwitch />
+          <input
+            className="bg-bg-secondary border-border-default h-full w-full border border-x-0 px-3 text-sm"
+            placeholder="https://api.example.com/path..."
+          />
+          <button className="bg-accent-blue border-accent-blue h-full w-28 rounded-r-md border px-3 py-2 text-sm font-medium text-white">
+            Send
+          </button>
+        </div>
+      </div>
+      <div className="col-start-1 row-start-2 flex items-end px-6 pb-0 text-sm">
+        <div
+          aria-orientation="horizontal"
+          className="flex flex-wrap gap-8"
+          role="tablist"
+        >
+          {TABS.map((tabOption) => {
+            const isActive = activeTab === tabOption;
+            return (
+              <button
+                aria-selected={isActive}
+                className={classNames(
+                  "text-text-secondary mb-1 font-bold transition-colors focus-visible:outline",
+                  isActive
+                    ? "decoration-accent-blue font-bold underline decoration-2 underline-offset-8"
+                    : "",
+                )}
+                key={tabOption}
+                onClick={() => setActiveTab(tabOption)}
+                role="tab"
+              >
+                {tabOption}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/[locale]/(protected)/_components/method-switch.tsx
+++ b/app/[locale]/(protected)/_components/method-switch.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { HTTP_METHODS } from "@/shared/globals";
+import { classNames } from "@/shared/styles";
+import type { HttpMethod } from "@/shared/types";
+
+export function MethodSwitch() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [method, setMethod] = useState<HttpMethod>(HTTP_METHODS[0]);
+  const rootReference = useRef<HTMLDivElement | null>(null);
+
+  const handleSelect = (m: HttpMethod) => {
+    setMethod(m);
+    setIsOpen(false);
+  };
+
+  return (
+    <div
+      className="relative h-full text-base"
+      data-current-method={method}
+      ref={rootReference}
+    >
+      <button
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-label="Select HTTP method"
+        className={classNames(
+          "bg-bg-secondary text-text-secondary border-border-default h-full w-28 border",
+          "flex items-center justify-between rounded-l-md px-2 py-1 font-medium transition-colors duration-300",
+        )}
+        onClick={() => setIsOpen((s) => !s)}
+        type="button"
+      >
+        <span className="sm:inline">{method}</span>
+        <svg
+          aria-hidden="true"
+          className={classNames(
+            "inline-block h-4 w-6",
+            "origin-center [transform-box:fill-box]",
+            "transition-transform duration-300",
+            isOpen && "rotate-180",
+          )}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path
+            d="M19 9l-7 4-7-4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+          />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          className="bg-bg-secondary absolute z-10 mt-1 w-40 shadow-lg"
+          role="listbox"
+        >
+          {HTTP_METHODS.map((methodOption) => {
+            const isActive = method === methodOption;
+            return (
+              <button
+                aria-selected={isActive}
+                className={classNames(
+                  "w-full cursor-pointer px-4 py-2 text-left transition-colors duration-200",
+                  isActive
+                    ? "bg-accent-blue font-semibold text-white"
+                    : "text-text-secondary hover:bg-border-default",
+                )}
+                key={methodOption}
+                onClick={() => handleSelect(methodOption)}
+                role="option"
+              >
+                {methodOption}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/[locale]/(protected)/_components/method-switch.tsx
+++ b/app/[locale]/(protected)/_components/method-switch.tsx
@@ -29,6 +29,7 @@ export function MethodSwitch() {
         className={classNames(
           "bg-bg-secondary text-text-secondary border-border-default h-full w-28 border",
           "flex items-center justify-between rounded-l-md px-2 py-1 font-medium transition-colors duration-300",
+          "cursor-pointer",
         )}
         onClick={() => setIsOpen((s) => !s)}
         type="button"

--- a/app/[locale]/(protected)/_components/metrics-bar.tsx
+++ b/app/[locale]/(protected)/_components/metrics-bar.tsx
@@ -1,1 +1,0 @@
-// props: { durationMs, status, reqBytes, resBytes }

--- a/app/[locale]/(protected)/_components/right-header-group.tsx
+++ b/app/[locale]/(protected)/_components/right-header-group.tsx
@@ -2,16 +2,17 @@ import { getTranslations } from "next-intl/server";
 
 export default async function RightHeaderGroup() {
   const t = await getTranslations("protected-header");
+
   return (
     <>
       <div className="text-text-secondary flex min-h-full items-center justify-evenly gap-4 px-6 pt-8 text-lg font-bold">
-        <span className="px-2 py-1">{t("protected-header.status")}</span>
-        <span className="px-2 py-1">{t("protected-header.size")}</span>
-        <span className="px-2 py-1">{t("protected-header.time")}</span>
+        <span className="px-2 py-1">{t("status")}</span>
+        <span className="px-2 py-1">{t("size")}</span>
+        <span className="px-2 py-1">{t("time")}</span>
       </div>
       <div className="col-start-3 row-start-2 flex items-end px-6">
         <span className="text-text-secondary decoration-accent-blue mb-1 text-sm font-bold underline decoration-2 underline-offset-8">
-          {t("protected-header.response")}
+          {t("response")}
         </span>
       </div>
     </>

--- a/app/[locale]/(protected)/_components/right-header-group.tsx
+++ b/app/[locale]/(protected)/_components/right-header-group.tsx
@@ -1,14 +1,17 @@
-export default function RightHeaderGroup() {
+import { getTranslations } from "next-intl/server";
+
+export default async function RightHeaderGroup() {
+  const t = await getTranslations("protected-header");
   return (
     <>
       <div className="text-text-secondary flex min-h-full items-center justify-evenly gap-4 px-6 pt-8 text-lg font-bold">
-        <span className="px-2 py-1">Status:</span>
-        <span className="px-2 py-1">Size:</span>
-        <span className="px-2 py-1">Time:</span>
+        <span className="px-2 py-1">{t("protected-header.status")}</span>
+        <span className="px-2 py-1">{t("protected-header.size")}</span>
+        <span className="px-2 py-1">{t("protected-header.time")}</span>
       </div>
       <div className="col-start-3 row-start-2 flex items-end px-6">
         <span className="text-text-secondary decoration-accent-blue mb-1 text-sm font-bold underline decoration-2 underline-offset-8">
-          Response
+          {t("protected-header.response")}
         </span>
       </div>
     </>

--- a/app/[locale]/(protected)/_components/right-header-group.tsx
+++ b/app/[locale]/(protected)/_components/right-header-group.tsx
@@ -1,0 +1,16 @@
+export default function RightHeaderGroup() {
+  return (
+    <>
+      <div className="text-text-secondary flex min-h-full items-center justify-evenly gap-4 px-6 pt-8 text-lg font-bold">
+        <span className="px-2 py-1">Status:</span>
+        <span className="px-2 py-1">Size:</span>
+        <span className="px-2 py-1">Time:</span>
+      </div>
+      <div className="col-start-3 row-start-2 flex items-end px-6">
+        <span className="text-text-secondary decoration-accent-blue mb-1 text-sm font-bold underline decoration-2 underline-offset-8">
+          Response
+        </span>
+      </div>
+    </>
+  );
+}

--- a/app/[locale]/(protected)/_components/sticky-header-grid.tsx
+++ b/app/[locale]/(protected)/_components/sticky-header-grid.tsx
@@ -1,0 +1,23 @@
+import LeftHeaderGroup from "@/app/[locale]/(protected)/_components/left-header-group";
+import RightHeaderGroup from "@/app/[locale]/(protected)/_components/right-header-group";
+import { classNames } from "@/shared/styles";
+
+export default function StickyHeaderGrid() {
+  return (
+    <div
+      className={classNames(
+        "bg-bg-primary border-border-default sticky top-16 z-30 grid " +
+          "h-28 grid-cols-[1fr_1px_1fr] grid-rows-[5rem_2rem] items-start" +
+          "gap-x-6 border-b",
+      )}
+    >
+      <div
+        aria-hidden
+        className="bg-border-default w col-start-2 row-span-2 h-full w-px"
+      />
+
+      <LeftHeaderGroup />
+      <RightHeaderGroup />
+    </div>
+  );
+}

--- a/app/[locale]/(protected)/_components/sticky-header-grid.tsx
+++ b/app/[locale]/(protected)/_components/sticky-header-grid.tsx
@@ -1,4 +1,4 @@
-import LeftHeaderGroup from "@/app/[locale]/(protected)/_components/left-header-group";
+import { LeftHeaderGroup } from "@/app/[locale]/(protected)/_components/left-header-group";
 import RightHeaderGroup from "@/app/[locale]/(protected)/_components/right-header-group";
 import { classNames } from "@/shared/styles";
 

--- a/app/[locale]/(protected)/_components/url-input.tsx
+++ b/app/[locale]/(protected)/_components/url-input.tsx
@@ -1,1 +1,0 @@
-//Input for the URL… provided in base64 on change

--- a/app/[locale]/(protected)/layout.tsx
+++ b/app/[locale]/(protected)/layout.tsx
@@ -1,7 +1,9 @@
+import { StickyHeaderGrid } from "@app/[locale]/(protected)/_components";
+
 export default function Layout() {
   return (
     <div style={{}}>
-      <h1>History</h1>
+      <StickyHeaderGrid />
     </div>
   );
 }

--- a/app/[locale]/(public)/layout.tsx
+++ b/app/[locale]/(public)/layout.tsx
@@ -1,7 +1,9 @@
-export default function PublicLayout() {
+import { StickyHeaderGrid } from "@app/[locale]/(protected)/_components";
+
+export default function Layout() {
   return (
     <div style={{}}>
-      <h1>Public Layout</h1>
+      <StickyHeaderGrid />
     </div>
   );
 }

--- a/app/[locale]/_components/header.tsx
+++ b/app/[locale]/_components/header.tsx
@@ -16,7 +16,7 @@ export default async function Header() {
           <LanguageSwitch />
           <button
             className={classNames(
-              "bg-bg-secondary hover:bg-border-default rounded-lg px-3 py-2",
+              "bg-bg-secondary rounded-lg px-3 py-2 hover:brightness-90",
               "font-medium transition-colors duration-300",
             )}
           >

--- a/app/[locale]/_components/header.tsx
+++ b/app/[locale]/_components/header.tsx
@@ -11,7 +11,7 @@ export default async function Header() {
   return (
     <section className="">
       <div className="bg-bg-primary flex flex-row items-center justify-between px-6 py-2">
-        <Image alt="logo" height={60} priority src={logoFull} width={150} />
+        <Image alt="logo" height={60} priority src={logoFull} />
         <div className="justify-space-between flex flex-row">
           <LanguageSwitch />
           <button

--- a/app/[locale]/_components/language-switch.tsx
+++ b/app/[locale]/_components/language-switch.tsx
@@ -23,7 +23,7 @@ export function LanguageSwitch() {
   };
 
   return (
-    <div className="relative">
+    <div className="relative z-100">
       <button
         aria-label="Select language"
         className={classNames(

--- a/app/[locale]/_components/language-switch.tsx
+++ b/app/[locale]/_components/language-switch.tsx
@@ -27,7 +27,7 @@ export function LanguageSwitch() {
       <button
         aria-label="Select language"
         className={classNames(
-          "text-text-primary hover:bg-border-default bg-bg-primary",
+          "text-text-primary hover:bg-border-default bg-bg-primary cursor-pointer",
           "items-center rounded-lg px-3 py-2 font-medium transition-colors duration-300",
         )}
         onClick={() => setIsListOpen(!isListOpen)}

--- a/shared/globals/globals.ts
+++ b/shared/globals/globals.ts
@@ -75,3 +75,21 @@ export const FOOTER_SECTIONS: Section[] = [
     titleKey: "sections.support.title",
   },
 ];
+
+export const HTTP_METHODS = [
+  "GET",
+  "POST",
+  "PATCH",
+  "DELETE",
+  "PUT",
+  "HEAD",
+  "OPTIONS",
+];
+
+export const TABS = [
+  "Headers",
+  "Body",
+  "Variables",
+  "CodeGen",
+  "Request History",
+];

--- a/shared/globals/index.ts
+++ b/shared/globals/index.ts
@@ -1,1 +1,1 @@
-export { FOOTER_SECTIONS, LANGUAGES } from "./globals";
+export { FOOTER_SECTIONS, HTTP_METHODS, LANGUAGES, TABS } from "./globals";

--- a/shared/lib/i18n/messages/be/protected-header.json
+++ b/shared/lib/i18n/messages/be/protected-header.json
@@ -1,11 +1,9 @@
 {
-  "protected-header": {
-    "sendButton": "Адправіць",
-    "status": "Статус:",
-    "size": "Памер:",
-    "time": "Час:",
-    "response": "Адказ"
-  },
+  "sendButton": "Адправіць",
+  "status": "Статус:",
+  "size": "Памер:",
+  "time": "Час:",
+  "response": "Адказ",
   "tabs": {
     "headers": "Загалоўкі",
     "body": "Цела запыту",

--- a/shared/lib/i18n/messages/be/protected-header.json
+++ b/shared/lib/i18n/messages/be/protected-header.json
@@ -1,0 +1,16 @@
+{
+  "protected-header": {
+    "sendButton": "Адправіць",
+    "status": "Статус:",
+    "size": "Памер:",
+    "time": "Час:",
+    "response": "Адказ"
+  },
+  "tabs": {
+    "headers": "Загалоўкі",
+    "body": "Цела запыту",
+    "variables": "Пераменныя",
+    "codegen": "Генерацыя кода",
+    "requestHistory": "Гісторыя запытаў"
+  }
+}

--- a/shared/lib/i18n/messages/be/protected-header.json
+++ b/shared/lib/i18n/messages/be/protected-header.json
@@ -10,7 +10,7 @@
     "headers": "Загалоўкі",
     "body": "Цела запыту",
     "variables": "Пераменныя",
-    "codegen": "Генерацыя кода",
-    "requestHistory": "Гісторыя запытаў"
+    "codegen": "Код",
+    "requestHistory": "Гісторыя"
   }
 }

--- a/shared/lib/i18n/messages/en/protected-header.json
+++ b/shared/lib/i18n/messages/en/protected-header.json
@@ -1,0 +1,16 @@
+{
+  "protected-header": {
+    "sendButton": "Send",
+    "status": "Status:",
+    "size": "Size:",
+    "time": "Time:",
+    "response": "Response"
+  },
+  "tabs": {
+    "headers": "Headers",
+    "body": "Body",
+    "variables": "Variables",
+    "codegen": "CodeGen",
+    "requestHistory": "Request History"
+  }
+}

--- a/shared/lib/i18n/messages/en/protected-header.json
+++ b/shared/lib/i18n/messages/en/protected-header.json
@@ -1,11 +1,9 @@
 {
-  "protected-header": {
-    "sendButton": "Send",
-    "status": "Status:",
-    "size": "Size:",
-    "time": "Time:",
-    "response": "Response"
-  },
+  "sendButton": "Send",
+  "status": "Status:",
+  "size": "Size:",
+  "time": "Time:",
+  "response": "Response",
   "tabs": {
     "headers": "Headers",
     "body": "Body",

--- a/shared/lib/i18n/messages/ru/protected-header.json
+++ b/shared/lib/i18n/messages/ru/protected-header.json
@@ -1,11 +1,9 @@
 {
-  "protected-header": {
-    "sendButton": "Отправить",
-    "status": "Статус:",
-    "size": "Размер:",
-    "time": "Время:",
-    "response": "Ответ"
-  },
+  "sendButton": "Отправить",
+  "status": "Статус:",
+  "size": "Размер:",
+  "time": "Время:",
+  "response": "Ответ",
   "tabs": {
     "headers": "Заголовки",
     "body": "Тело запроса",

--- a/shared/lib/i18n/messages/ru/protected-header.json
+++ b/shared/lib/i18n/messages/ru/protected-header.json
@@ -1,0 +1,16 @@
+{
+  "protected-header": {
+    "sendButton": "Отправить",
+    "status": "Статус:",
+    "size": "Размер:",
+    "time": "Время:",
+    "response": "Ответ"
+  },
+  "tabs": {
+    "headers": "Заголовки",
+    "body": "Тело запроса",
+    "variables": "Переменные",
+    "codegen": "Генерация кода",
+    "requestHistory": "История запросов"
+  }
+}

--- a/shared/lib/i18n/messages/ru/protected-header.json
+++ b/shared/lib/i18n/messages/ru/protected-header.json
@@ -10,7 +10,7 @@
     "headers": "Заголовки",
     "body": "Тело запроса",
     "variables": "Переменные",
-    "codegen": "Генерация кода",
-    "requestHistory": "История запросов"
+    "codegen": "Kод",
+    "requestHistory": "История"
   }
 }

--- a/shared/lib/i18n/request.ts
+++ b/shared/lib/i18n/request.ts
@@ -6,6 +6,10 @@ import { getRequestConfig } from "next-intl/server";
 
 import { routing } from "@/shared/lib/i18n/routing";
 
+interface NestedMessages {
+  [key: string]: NestedMessages | string;
+}
+
 async function loadMessages(locale: string) {
   const directory = path.join(
     process.cwd(),
@@ -13,7 +17,7 @@ async function loadMessages(locale: string) {
     locale,
   );
   const files = await fs.readdir(directory);
-  const messages: Record<string, string> = {};
+  const messages: Record<string, NestedMessages> = {};
 
   for (const file of files) {
     if (file.endsWith(".json")) {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,1 +1,1 @@
-export type { Language, Section } from "./types";
+export type { HttpMethod, Language, Section } from "./types";

--- a/shared/types/types.ts
+++ b/shared/types/types.ts
@@ -1,3 +1,6 @@
+export type HttpMethod = (typeof HTTP_METHODS)[number];
+import { HTTP_METHODS } from "@/shared/globals";
+
 export interface Language {
   code: "be" | "en" | "ru";
   name: string;


### PR DESCRIPTION
<img width="1080" height="178" alt="Screenshot 2025-09-08 at 11 42 11" src="https://github.com/user-attachments/assets/cfa7c6a3-64ac-497b-a29d-91d7c426a1f8" />


# PR: Add Protected Zone Header Components

## Summary
- Added **MethodSwitch** component for HTTP method selection
- Implemented **LeftHeaderGroup** with method selector, input field, Send button, and tab navigation
- Implemented **RightHeaderGroup** with status, size, time indicators, and response label
- Added **StickyHeaderGrid** to combine left/right header groups in a unified layout 
- Updated **Protected Layout** to include sticky header grid:contentReference

## Notes
All components are styled with Tailwind and localized, but there is an error: "Could not resolve `tabs` in messages for locale `be`/`en`/`ru`", which I can't resolve. I'll try in the evening one more time, but if someone can look at it and help me debugging - it would be great.

## Important
Components are nested at `app/[locale]/public/layout.tsx` because we don't have protected zone yet. But component files are in `app/[locale]/public/_components` folder