### PR TITLE
Page structure in protected zone (#32)

### DIFF
--- a/app/[locale]/(protected)/_components/body-editor.tsx
+++ b/app/[locale]/(protected)/_components/body-editor.tsx
@@ -1,1 +1,9 @@
-//Request body editor / JSON viewer… support prettifying; JSON & plain text
+import { useSelector } from "react-redux";
+
+import { RootState } from "@store/store";
+
+export function BodyEditor() {
+  const activeTab = useSelector((state: RootState) => state.tabs.activeTab);
+  const isHeadersOpen = activeTab === "body";
+  return isHeadersOpen && <div className="text-5xl">BODY</div>;
+}

--- a/app/[locale]/(protected)/_components/codegener-panel.tsx
+++ b/app/[locale]/(protected)/_components/codegener-panel.tsx
@@ -1,1 +1,9 @@
-//Generated code section… support at least: curl, JS(fetch/xhr), NodeJS, Python, Java, C#, Go
+import { useSelector } from "react-redux";
+
+import { RootState } from "@store/store";
+
+export function CodegenerPanel() {
+  const activeTab = useSelector((state: RootState) => state.tabs.activeTab);
+  const isHeadersOpen = activeTab === "codegen";
+  return isHeadersOpen && <div className="text-5xl">CODE GENERATOR</div>;
+}

--- a/app/[locale]/(protected)/_components/headers-editor.tsx
+++ b/app/[locale]/(protected)/_components/headers-editor.tsx
@@ -1,2 +1,9 @@
-// methods = ["GET","POST","PUT","DELETE","PATCH","HEAD","OPTIONS"]
-// onChange -> navigate(`/METHOD/${endpointB64}/${optionalBodyB64}?...`)
+import { useSelector } from "react-redux";
+
+import { RootState } from "@store/store";
+
+export function HeadersEditor() {
+  const activeTab = useSelector((state: RootState) => state.tabs.activeTab);
+  const isHeadersOpen = activeTab === "headers";
+  return isHeadersOpen && <div className="text-5xl">HEADERS</div>;
+}

--- a/app/[locale]/(protected)/_components/left-header-group.tsx
+++ b/app/[locale]/(protected)/_components/left-header-group.tsx
@@ -1,24 +1,29 @@
 "use client";
 
-import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { useTranslations } from "next-intl";
 
+import { TabOpenState } from "@shared/types";
+
 import { MethodSwitch } from "@app/[locale]/(protected)/_components/method-switch";
+import { setActiveTab } from "@store/slices/tab-open-slice";
+import { RootState } from "@store/store";
 
 import { classNames } from "@/shared/styles";
 
+type TabKey = TabOpenState["activeTab"];
+
 export function LeftHeaderGroup() {
   const t = useTranslations("protected-header");
-
+  const dispatch = useDispatch();
+  const activeTab = useSelector((state: RootState) => state.tabs.activeTab);
   const tabs = [
     { key: "headers", label: t("tabs.headers") },
     { key: "body", label: t("tabs.body") },
     { key: "variables", label: t("tabs.variables") },
     { key: "codegen", label: t("tabs.codegen") },
     { key: "requestHistory", label: t("tabs.requestHistory") },
-  ];
-
-  const [activeTab, setActiveTab] = useState<string>(tabs[0].key);
+  ] as const satisfies readonly { key: TabKey; label: string }[];
 
   return (
     <>
@@ -58,7 +63,7 @@ export function LeftHeaderGroup() {
                     "decoration-accent-blue font-bold underline decoration-2 underline-offset-8",
                 )}
                 key={key}
-                onClick={() => setActiveTab(key)}
+                onClick={() => dispatch(setActiveTab(key))}
                 role="tab"
               >
                 {label}

--- a/app/[locale]/(protected)/_components/left-pane.tsx
+++ b/app/[locale]/(protected)/_components/left-pane.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { BodyEditor } from "@app/[locale]/(protected)/_components/body-editor";
+import { CodegenerPanel } from "@app/[locale]/(protected)/_components/codegener-panel";
+import { HeadersEditor } from "@app/[locale]/(protected)/_components/headers-editor";
+import { HistoryTable } from "@app/[locale]/(protected)/_components/history-table";
+import { VariablesEditor } from "@app/[locale]/(protected)/_components/variables-editor";
+
+export function LeftPane() {
+  return (
+    <div className="col-start-1">
+      <HeadersEditor />
+      <BodyEditor />
+      <CodegenerPanel />
+      <VariablesEditor />
+      <HistoryTable />
+    </div>
+  );
+}

--- a/app/[locale]/(protected)/_components/method-selector.tsx
+++ b/app/[locale]/(protected)/_components/method-selector.tsx
@@ -1,1 +1,0 @@
-// a dropdown (select) with HTTP methods: GET, POST, PUT, DELETE, PATCH

--- a/app/[locale]/(protected)/_components/page-grid.tsx
+++ b/app/[locale]/(protected)/_components/page-grid.tsx
@@ -1,10 +1,17 @@
+import { MOCK_RESPONSE } from "@shared/globals";
+
+import { LeftPane } from "@app/[locale]/(protected)/_components/left-pane";
+import { ResponsePane } from "@app/[locale]/(protected)/_components/response-panel";
+
 export function PageGrid() {
   return (
     <div className="grid grid-cols-[1fr_1px_1fr] gap-x-6">
       <div
         aria-hidden
-        className="bg-border-default col-start-2 row-span-full h-full w-px"
+        className="bg-border-default w col-start-2 row-span-2 h-full w-px"
       />
+      <LeftPane />
+      <ResponsePane response={MOCK_RESPONSE} />
     </div>
   );
 }

--- a/app/[locale]/(protected)/_components/page-grid.tsx
+++ b/app/[locale]/(protected)/_components/page-grid.tsx
@@ -1,0 +1,10 @@
+export function PageGrid() {
+  return (
+    <div className="grid grid-cols-[1fr_1px_1fr] gap-x-6">
+      <div
+        aria-hidden
+        className="bg-border-default col-start-2 row-span-full h-full w-px"
+      />
+    </div>
+  );
+}

--- a/app/[locale]/(protected)/_components/response-panel.tsx
+++ b/app/[locale]/(protected)/_components/response-panel.tsx
@@ -1,0 +1,27 @@
+import { ResponsePaneProps } from "@shared/types";
+
+import { classNames } from "@/shared/styles";
+
+export function ResponsePane({ response }: ResponsePaneProps) {
+  const lines = response.split("\n");
+
+  return (
+    <div
+      className={classNames(
+        "bg-bg-secondary border-border-default rounded-md border",
+        "max-h-[calc(100vh-12rem)] overflow-auto font-mono text-sm",
+      )}
+    >
+      <pre className="m-0 p-4">
+        {lines.map((line, index) => (
+          <div className="flex" key={index}>
+            <span className="text-text-tertiary w-10 pr-4 text-right select-none">
+              {index + 1}
+            </span>
+            <span className="break-words whitespace-pre-wrap">{line}</span>
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}

--- a/app/[locale]/(protected)/_components/response-panel.tsx
+++ b/app/[locale]/(protected)/_components/response-panel.tsx
@@ -1,17 +1,10 @@
 import { ResponsePaneProps } from "@shared/types";
 
-import { classNames } from "@/shared/styles";
-
 export function ResponsePane({ response }: ResponsePaneProps) {
   const lines = response.split("\n");
 
   return (
-    <div
-      className={classNames(
-        "bg-bg-secondary border-border-default rounded-md border",
-        "max-h-[calc(100vh-12rem)] overflow-auto font-mono text-sm",
-      )}
-    >
+    <div className="col-start-3 max-h-[calc(100vh-12rem)] overflow-auto font-mono text-sm">
       <pre className="m-0 p-4">
         {lines.map((line, index) => (
           <div className="flex" key={index}>

--- a/app/[locale]/(protected)/_components/variables-editor.tsx
+++ b/app/[locale]/(protected)/_components/variables-editor.tsx
@@ -2,8 +2,8 @@ import { useSelector } from "react-redux";
 
 import { RootState } from "@store/store";
 
-export function HistoryTable() {
+export function VariablesEditor() {
   const activeTab = useSelector((state: RootState) => state.tabs.activeTab);
-  const isHeadersOpen = activeTab === "requestHistory";
-  return isHeadersOpen && <div className="text-5xl">REQUEST HISTORY</div>;
+  const isHeadersOpen = activeTab === "variables";
+  return isHeadersOpen && <div className="text-5xl">VARIABLES</div>;
 }

--- a/app/[locale]/(protected)/layout.tsx
+++ b/app/[locale]/(protected)/layout.tsx
@@ -1,9 +1,7 @@
-import { StickyHeaderGrid } from "@app/[locale]/(protected)/_components";
-
 export default function Layout() {
   return (
     <div style={{}}>
-      <StickyHeaderGrid />
+      <h1>History</h1>
     </div>
   );
 }

--- a/app/[locale]/(public)/layout.tsx
+++ b/app/[locale]/(public)/layout.tsx
@@ -1,13 +1,11 @@
-import { Metadata } from "next";
-
 import { StickyHeaderGrid } from "@app/[locale]/(protected)/_components";
+import { PageGrid } from "@app/[locale]/(protected)/_components/page-grid";
 
-export const metadata: Metadata = { title: "PingPong" };
-
-export default function Layout() {
+export default function PublicLayout() {
   return (
     <div style={{}}>
       <StickyHeaderGrid />
+      <PageGrid />
     </div>
   );
 }

--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -2,12 +2,8 @@
 
 export default function GlobalError() {
   return (
-    <html>
-      <body>
-        <div style={{ padding: 24 }}>
-          <h2>Something went wrong</h2>
-        </div>
-      </body>
-    </html>
+    <div style={{ padding: 24 }}>
+      <h2>Something went wrong</h2>\{" "}
+    </div>
   );
 }

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -4,6 +4,7 @@ import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { getMessages, setRequestLocale } from "next-intl/server";
 
 import { Footer, Header } from "@app/[locale]/_components";
+import { ReduxProvider } from "@store/provider";
 
 import "@/shared/styles/globals.css";
 
@@ -32,11 +33,13 @@ export default async function LocaleLayout({
   return (
     <html lang={locale}>
       <body className="bg-bg-primary text-base">
-        <NextIntlClientProvider locale={locale} messages={messages}>
-          <Header />
-          {children}
-          <Footer />
-        </NextIntlClientProvider>
+        <ReduxProvider>
+          <NextIntlClientProvider locale={locale} messages={messages}>
+            <Header />
+            {children}
+            <Footer />
+          </NextIntlClientProvider>
+        </ReduxProvider>
       </body>
     </html>
   );

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -2,12 +2,8 @@
 
 export default function NotFound() {
   return (
-    <html>
-      <body>
-        <div style={{ padding: 24 }}>
-          <h2>NotFound</h2>
-        </div>
-      </body>
-    </html>
+    <div style={{ padding: 24 }}>
+      <h2>NotFound</h2>
+    </div>
   );
 }

--- a/shared/globals/globals.ts
+++ b/shared/globals/globals.ts
@@ -93,3 +93,37 @@ export const TABS = [
   "CodeGen",
   "Request History",
 ];
+
+export const MOCK_RESPONSE = `{
+  "status": 200,
+  "statusText": "OK",
+  "headers": {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-cache",
+    "x-request-id": "abc123xyz"
+  },
+  "body": {
+    "user": {
+      "id": 42,
+      "name": "Jane Doe",
+      "email": "jane.doe@example.com",
+      "roles": ["admin", "editor"]
+    },
+    "posts": [
+      {
+        "id": 101,
+        "title": "Hello World",
+        "created_at": "2025-09-09T10:15:00Z"
+      },
+      {
+        "id": 102,
+        "title": "REST Client Example",
+        "created_at": "2025-09-09T10:20:00Z"
+      }
+    ]
+  },
+  "meta": {
+    "request_duration_ms": 123,
+    "response_size_bytes": 456
+  }
+}`;

--- a/shared/globals/index.ts
+++ b/shared/globals/index.ts
@@ -1,1 +1,7 @@
-export { FOOTER_SECTIONS, HTTP_METHODS, LANGUAGES, TABS } from "./globals";
+export {
+  FOOTER_SECTIONS,
+  HTTP_METHODS,
+  LANGUAGES,
+  MOCK_RESPONSE,
+  TABS,
+} from "./globals";

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,1 +1,1 @@
-export type { HttpMethod, Language, Section } from "./types";
+export type { HttpMethod, Language, ResponsePaneProps, Section } from "./types";

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,1 +1,7 @@
-export type { HttpMethod, Language, ResponsePaneProps, Section } from "./types";
+export type {
+  HttpMethod,
+  Language,
+  ResponsePaneProps,
+  Section,
+  TabOpenState,
+} from "./types";

--- a/shared/types/types.ts
+++ b/shared/types/types.ts
@@ -12,6 +12,10 @@ export interface LinkItem {
   labelKey: string;
 }
 
+export interface ResponsePaneProps {
+  response: string;
+}
+
 export interface Section {
   id: string;
   links: LinkItem[];

--- a/shared/types/types.ts
+++ b/shared/types/types.ts
@@ -21,3 +21,7 @@ export interface Section {
   links: LinkItem[];
   titleKey: string;
 }
+
+export interface TabOpenState {
+  activeTab: "body" | "codegen" | "headers" | "requestHistory" | "variables";
+}

--- a/store/provider.tsx
+++ b/store/provider.tsx
@@ -1,1 +1,10 @@
-//<Provider store={store}>
+"use client";
+
+import { ReactNode } from "react";
+import { Provider } from "react-redux";
+
+import { store } from "@/store/store";
+
+export function ReduxProvider({ children }: { children: ReactNode }) {
+  return <Provider store={store}>{children}</Provider>;
+}

--- a/store/slices/tab-open-slice.ts
+++ b/store/slices/tab-open-slice.ts
@@ -1,0 +1,19 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { TabOpenState } from "@shared/types";
+
+const initialState: TabOpenState = {
+  activeTab: "headers",
+};
+
+const tabSlice = createSlice({
+  name: "tabs",
+  initialState,
+  reducers: {
+    setActiveTab: (state, action: PayloadAction<TabOpenState["activeTab"]>) => {
+      state.activeTab = action.payload;
+    },
+  },
+});
+
+export const { setActiveTab } = tabSlice.actions;
+export default tabSlice.reducer;

--- a/store/store.ts
+++ b/store/store.ts
@@ -1,0 +1,12 @@
+import { configureStore } from "@reduxjs/toolkit";
+
+import tabReducer from "@/store/slices/tab-open-slice";
+
+export const store = configureStore({
+  reducer: {
+    tabs: tabReducer,
+  },
+});
+
+export type AppDispatch = typeof store.dispatch;
+export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION


https://github.com/user-attachments/assets/f6d7dd39-541b-4c22-8983-e7c58657cc89


## Summary
Introduces the new two-pane layout with a right-side Response panel, adds Redux-driven tab state for the left pane editors, and fixes hydration issues by removing invalid `<html>/<body>` from `error.tsx` and `not-found.tsx`. Also wires Redux Provider into the locale layout.

## What’s included
- **Layout & UI**
  - New `PageGrid` with **1fr | divider | 1fr** columns; left editors + right Response panel.
  - **Response panel**: monospace, line numbers, scrollable container rendering `MOCK_RESPONSE`.
- **State management**
  - **Redux store** and `ReduxProvider` added; wrapped in `app/[locale]/layout.tsx`.
  - `tabs` slice with `activeTab` and `setActiveTab`.
  - `LeftHeaderGroup` now dispatches tab changes; editors show conditionally by active tab.
- **Client/Server boundaries**
  - `LeftPane` marked `"use client"` to safely host Redux hooks in child editors.
- **Error handling**
  - Removed `<html>/<body>` from `error.tsx` and `not-found.tsx` to prevent hydration errors.

## Notes
- This lays the groundwork for real editors (headers/body/vars) and response rendering; mock JSON is centralized in `shared/globals`.

## Important
It is still nested in public layout - we should plan moving those components to protected zone 
