### PR TITLE
History and analytics (#52)

### DIFF
--- a/app/[locale]/(auth)/layout.tsx
+++ b/app/[locale]/(auth)/layout.tsx
@@ -1,13 +1,12 @@
 import { redirect } from "next/navigation";
 
+import { LayoutProps } from "@shared/types/types";
+
 import { getServerSession } from "@/shared/lib/auth/get-session";
 
-export default async function AuthLayout({
-  children,
-  params,
-}: LayoutProps<"/[locale]">) {
+export default async function AuthLayout({ children, params }: LayoutProps) {
   const session = await getServerSession();
-  const { locale } = await params;
+  const { locale } = params;
   if (session) {
     redirect(`/${locale}/workspace`);
   }

--- a/app/[locale]/(protected)/_components/history-table.tsx
+++ b/app/[locale]/(protected)/_components/history-table.tsx
@@ -1,9 +1,93 @@
-import { useSelector } from "react-redux";
+"use client";
 
-import { RootState } from "@store/store";
+import { useDispatch, useSelector } from "react-redux";
+
+import { Button } from "@app/[locale]/(auth)/_components/form-button";
+
+import Table from "@/shared/ui/table";
+import { setBody } from "@/store/slices/body-editor-slice";
+import type { HistoryEntry } from "@/store/slices/history-slice";
+import { setSelectedMethod } from "@/store/slices/method-slice";
+import { clearResponse } from "@/store/slices/request-slice";
+import { setUrl } from "@/store/slices/url-slice";
+import type { RootState } from "@/store/store";
+import { getStatusColor } from "@/utils/helpers/get-status-color";
 
 export function HistoryTable() {
-  const activeTab = useSelector((state: RootState) => state.tabs.activeTab);
-  const isHeadersOpen = activeTab === "requestHistory";
-  return isHeadersOpen && <div className="text-5xl">REQUEST HISTORY</div>;
+  const dispatch = useDispatch();
+
+  const activeTab = useSelector((s: RootState) => s.tabs.activeTab);
+  const entries = useSelector((s: RootState) => s.history.entries);
+  const isOpen = activeTab === "requestHistory";
+
+  const restore = (entry: HistoryEntry) => {
+    dispatch(setSelectedMethod(entry.request.method));
+    dispatch(setUrl(entry.request.url));
+    dispatch(setBody(entry.request.body ?? ""));
+    dispatch(clearResponse());
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div className="text-muted-foreground p-4 text-sm">
+        No requests yet. Run one in the REST client — history will appear here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Request History</h2>
+        <div className="flex items-center gap-2">
+          <Button>Re-run</Button>
+        </div>
+      </div>
+
+      <Table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>Status</th>
+            <th>Time</th>
+            <th>Endpoint</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry) => {
+            const status = entry.response?.status ?? null;
+            const durationMs = entry.response?.meta?.requestDurationMs;
+
+            return (
+              <tr
+                className="cursor-pointer"
+                key={entry.id}
+                onClick={() => restore(entry)}
+              >
+                <td className="font-mono">{entry.request.method}</td>
+                <td className={`font-mono ${getStatusColor(status)}`}>
+                  {status ?? "—"}
+                </td>
+                <td title={new Date(entry.createdAt).toLocaleString()}>
+                  {typeof durationMs === "number"
+                    ? `${durationMs} ms`
+                    : new Date(entry.createdAt).toLocaleTimeString()}
+                </td>
+                <td
+                  className="max-w-[540px] truncate"
+                  title={entry.request.url}
+                >
+                  {entry.request.url}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
+    </div>
+  );
 }

--- a/app/[locale]/(protected)/workspace/[method]/page.tsx
+++ b/app/[locale]/(protected)/workspace/[method]/page.tsx
@@ -1,14 +1,14 @@
-//http://localhost:3000/ru/main/GET?page=2&filter=name
+//http://localhost:3000/ru/workspace/GET?page=2&filter=name
 
 export default async function Page({
   params,
   searchParams,
 }: {
-  params: Promise<{ locale: string; method: string }>;
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+  params: { locale: string; method: string };
+  searchParams?: Record<string, string | string[] | undefined>;
 }) {
-  const { locale, method } = await params;
-  const resolvedSearchParams = (await searchParams) || {};
+  const { locale, method } = params;
+  const resolvedSearchParams = searchParams || {};
 
   return (
     <div>

--- a/app/[locale]/api/auth/login/route.ts
+++ b/app/[locale]/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getSessionCookieName } from "@/shared/lib/auth/cookies";
 import { adminAuth } from "@/shared/lib/firebase/admin";
 
 const SECONDS_IN_MINUTE = 60;
@@ -27,7 +28,8 @@ export async function POST(request: NextRequest) {
     });
 
     const response = NextResponse.json({ ok: true });
-    response.cookies.set(process.env.SESSION_NAME ?? "session", sessionCookie, {
+    const name = getSessionCookieName();
+    response.cookies.set(name, sessionCookie, {
       httpOnly: true,
       maxAge: sessionMaxAgeSeconds,
       path: "/",

--- a/app/[locale]/api/auth/logout/route.ts
+++ b/app/[locale]/api/auth/logout/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from "next/server";
 
+import { getSessionCookieName } from "@/shared/lib/auth/cookies";
+
 export async function POST() {
   const response = NextResponse.json({ ok: true });
-  response.cookies.set(process.env.SESSION_NAME ?? "session", "", {
+  response.cookies.set(getSessionCookieName(), "", {
     httpOnly: true,
     maxAge: 0,
     path: "/",

--- a/app/[locale]/api/auth/session/route.ts
+++ b/app/[locale]/api/auth/session/route.ts
@@ -1,12 +1,13 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
+import { getSessionCookieName } from "@/shared/lib/auth/cookies";
 import { adminAuth } from "@/shared/lib/firebase/admin";
 
 export const runtime = "nodejs";
 
 export async function GET() {
-  const name = process.env.SESSION_NAME ?? "session";
+  const name = getSessionCookieName();
   const cookiesStore = await cookies();
   const token = cookiesStore.get(name)?.value;
 

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,7 +1,38 @@
-// An SSR page fetches the user's history and analytics
-// History must be server-side generated and loaded from DB
+export const runtime = "nodejs";
+
 import { NextResponse } from "next/server";
 
-export async function GET() {
-  return NextResponse.json({ ok: true });
+import { getHistory } from "@/utils/server/history-store";
+import { uidFromRequest } from "@/utils/server/uid-from-request";
+
+export async function GET(request: Request) {
+  const uid = await uidFromRequest(request);
+  if (!uid) {
+    return Response.json({ items: [] }, { status: 200 });
+  }
+  const raw = await getHistory(uid);
+  const items = raw.map((it) => ({
+    id: it.id,
+    createdAt: new Date(it.timestamp).toISOString(),
+    request: {
+      method: it.method,
+      url: it.url,
+      body: typeof it.body === "string" ? it.body : undefined,
+      headers: [],
+      meta: { contentType: null, jsonMode: false },
+    },
+    response: {
+      status: it.status,
+      statusText: it.statusText,
+      headers: it.headers ?? {},
+      body: null,
+      meta: {
+        requestDurationMs: it.duration,
+        requestSizeBytes: it.requestSize,
+        responseSizeBytes: it.responseSize,
+        requestTimestamp: new Date(it.timestamp).toISOString(),
+      },
+    },
+  }));
+  return NextResponse.json({ items });
 }

--- a/app/api/request/route.ts
+++ b/app/api/request/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
+import { addHistory } from "@/utils/server/history-store";
+import { uidFromRequest } from "@/utils/server/uid-from-request";
+
 export async function POST(request: Request) {
+  const startedAt = Date.now();
+
   try {
     const { method, url, headers, body } = await request.json();
 
@@ -34,6 +41,33 @@ export async function POST(request: Request) {
       status: result.status,
       timestamp: new Date().toISOString(),
     });
+
+    try {
+      const uid = await uidFromRequest(request);
+      if (uid) {
+        const requestSize = body ? Buffer.byteLength(body, "utf8") : 0;
+        const responseSize = responseText
+          ? Buffer.byteLength(responseText, "utf8")
+          : 0;
+
+        await addHistory(uid, {
+          timestamp: Date.now(),
+          url,
+          method,
+          status: result.status,
+          statusText: result.statusText,
+          duration: Date.now() - startedAt,
+          requestSize,
+          responseSize,
+          headers: responseHeaders,
+          body: body || {},
+        });
+      } else {
+        console.warn("Failed to get uid from request");
+      }
+    } catch (error) {
+      console.warn("Failed to append history:", error);
+    }
 
     return NextResponse.json(result);
   } catch (error) {

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+import { getIdToken, onAuthStateChanged } from "firebase/auth";
+
+import { setHistory } from "@store/slices/history-slice";
+
+import { auth } from "@/shared/lib/firebase/client";
+
+export function AuthProvider() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, async (user) => {
+      try {
+        const token = user ? await getIdToken(user, false) : null;
+        const resp = await fetch("/api/history", {
+          credentials: "include",
+          cache: "no-store",
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!resp.ok) {
+          dispatch(setHistory([]));
+          return;
+        }
+        const { items } = await resp.json();
+        dispatch(setHistory(items));
+      } catch {
+        dispatch(setHistory([]));
+      }
+    });
+
+    return () => unsub();
+  }, [dispatch]);
+
+  return null;
+}

--- a/shared/lib/auth/cookies.ts
+++ b/shared/lib/auth/cookies.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_SESSION_COOKIE_NAME = "session" as const;
+
+export function getSessionCookieName(): string {
+  return process.env.SESSION_NAME ?? DEFAULT_SESSION_COOKIE_NAME;
+}

--- a/shared/lib/auth/get-session.ts
+++ b/shared/lib/auth/get-session.ts
@@ -2,10 +2,11 @@ import "server-only";
 
 import { cookies } from "next/headers";
 
+import { getSessionCookieName } from "@/shared/lib/auth/cookies";
 import { adminAuth } from "@/shared/lib/firebase/admin";
 
 export async function getServerSession() {
-  const name = process.env.SESSION_NAME ?? "session";
+  const name = getSessionCookieName();
   const cookiesStore = await cookies();
   const token = cookiesStore.get(name)?.value;
   if (!token) {

--- a/shared/lib/firebase/admin.ts
+++ b/shared/lib/firebase/admin.ts
@@ -13,3 +13,4 @@ if (!admin.apps.length) {
 }
 
 export const adminAuth = admin.auth();
+export const adminDatabase = admin.firestore();

--- a/shared/lib/firebase/firebase.ts
+++ b/shared/lib/firebase/firebase.ts
@@ -36,4 +36,4 @@ const initializeAnalytics = () => {
 };
 
 initializeAnalytics();
-export { analytics };
+export { analytics, app };

--- a/shared/types/types.ts
+++ b/shared/types/types.ts
@@ -182,6 +182,11 @@ export interface Language {
   name: string;
 }
 
+export interface LayoutProps {
+  children: ReactNode;
+  params: Record<string, string>;
+}
+
 export interface LinkItem {
   external?: boolean;
   href: string;

--- a/shared/ui/table.tsx
+++ b/shared/ui/table.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as React from "react";
+
+export type SimpleTableProps = React.TableHTMLAttributes<HTMLTableElement>;
+
+const SimpleTable = React.forwardRef<HTMLTableElement, SimpleTableProps>(
+  ({ className = "", children, ...props }, reference) => {
+    return (
+      <div className="overflow-x-auto">
+        <table
+          className={`w-full border border-gray-200 text-sm ${className}`}
+          ref={reference}
+          {...props}
+        >
+          {children}
+        </table>
+      </div>
+    );
+  },
+);
+
+SimpleTable.displayName = "SimpleTable";
+export default SimpleTable;

--- a/store/provider.tsx
+++ b/store/provider.tsx
@@ -3,8 +3,14 @@
 import { ReactNode } from "react";
 import { Provider } from "react-redux";
 
+import { AuthProvider } from "@/providers/AuthProvider";
 import { store } from "@/store/store";
 
 export function ReduxProvider({ children }: { children: ReactNode }) {
-  return <Provider store={store}>{children}</Provider>;
+  return (
+    <Provider store={store}>
+      <AuthProvider />
+      {children}
+    </Provider>
+  );
 }

--- a/store/slices/history-slice.ts
+++ b/store/slices/history-slice.ts
@@ -28,9 +28,12 @@ const historySlice = createSlice({
     clearHistory: (state) => {
       state.entries = [];
     },
+    setHistory: (state, action: PayloadAction<HistoryEntry[]>) => {
+      state.entries = action.payload;
+    },
   },
 });
 
-export const { addEntry, clearHistory } = historySlice.actions;
+export const { addEntry, clearHistory, setHistory } = historySlice.actions;
 export const selectHistory = (state: RootState) => state.history.entries;
 export default historySlice.reducer;

--- a/utils/server/history-store.ts
+++ b/utils/server/history-store.ts
@@ -1,0 +1,56 @@
+import { adminDatabase } from "@/shared/lib/firebase/admin";
+
+export interface HistoryEntry {
+  body?: string;
+  duration: number;
+  error?: string;
+  headers?: Record<string, string>;
+  method: string;
+  requestSize: number;
+  responseSize: number;
+  status: number;
+  statusText: string;
+  timestamp: number;
+  url: string;
+}
+
+export type HistoryWithId = HistoryEntry & { id: string };
+
+export async function addHistory(
+  uid: string,
+  entry: HistoryEntry,
+): Promise<string> {
+  const reference = adminDatabase
+    .collection("users")
+    .doc(uid)
+    .collection("history")
+    .doc();
+  await reference.set(entry);
+  return reference.id;
+}
+
+export async function getHistory(uid: string): Promise<HistoryWithId[]> {
+  const snap = await adminDatabase
+    .collection("users")
+    .doc(uid)
+    .collection("history")
+    .orderBy("timestamp", "desc")
+    .get();
+  return snap.docs.map((document_) => {
+    const data = document_.data();
+    return {
+      id: document_.id,
+      body: data.body,
+      duration: data.duration,
+      error: data.error,
+      headers: data.headers,
+      method: data.method,
+      requestSize: data.requestSize,
+      responseSize: data.responseSize,
+      status: data.status,
+      statusText: data.statusText,
+      timestamp: data.timestamp,
+      url: data.url,
+    };
+  });
+}

--- a/utils/server/uid-from-request.ts
+++ b/utils/server/uid-from-request.ts
@@ -1,16 +1,16 @@
-import { adminAuth } from "@shared/lib/firebase/admin";
-
-const ID_TOKEN_COOKIE = "session" as const;
+import { getSessionCookieName } from "@/shared/lib/auth/cookies";
+import { adminAuth } from "@/shared/lib/firebase/admin";
 
 export async function uidFromRequest(
   request: Request,
 ): Promise<string | undefined> {
   try {
     const cookieHeader = request.headers.get("cookie") ?? "";
+    const sessionCookieName = getSessionCookieName();
     const sessionCookie = cookieHeader
       .split(";")
       .map((s) => s.trim())
-      .find((s) => s.startsWith(`${ID_TOKEN_COOKIE}=`))
+      .find((s) => s.startsWith(`${sessionCookieName}=`))
       ?.split("=")[1];
 
     const authHeader = request.headers.get("authorization") ?? "";

--- a/utils/server/uid-from-request.ts
+++ b/utils/server/uid-from-request.ts
@@ -1,0 +1,35 @@
+import { adminAuth } from "@shared/lib/firebase/admin";
+
+const ID_TOKEN_COOKIE = "session" as const;
+
+export async function uidFromRequest(
+  request: Request,
+): Promise<string | undefined> {
+  try {
+    const cookieHeader = request.headers.get("cookie") ?? "";
+    const sessionCookie = cookieHeader
+      .split(";")
+      .map((s) => s.trim())
+      .find((s) => s.startsWith(`${ID_TOKEN_COOKIE}=`))
+      ?.split("=")[1];
+
+    const authHeader = request.headers.get("authorization") ?? "";
+    const bearer = authHeader.startsWith("Bearer ")
+      ? authHeader.slice("Bearer ".length)
+      : undefined;
+
+    if (sessionCookie) {
+      const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+      return decoded.uid;
+    }
+
+    if (bearer) {
+      const decoded = await adminAuth.verifyIdToken(bearer, true);
+      return decoded.uid;
+    }
+
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
### What I did

- Implemented request UID extraction via ```uidFromRequest```:
- Supports session cookie (session) and Bearer token.  **I’m not sure which one we should keep**
- Uses ```adminAuth.verifySessionCookie(..., true)``` / ```verifyIdToken(..., true)``` with revocation checks.
- Added Firestore history layer (Firebase Admin)

### Functions:

- ```addHistory(uid, entry)``` → writes to ```/users/{uid}/history/{autoId}```.
- ```getHistory(uid)``` → reads entries ordered by timestamp DESC.
- Wired Redux provider:
   1. Wrap the app with ```<Provider store={store}>```.
   2. Mount ```<AuthProvider />``` inside the provider

### How I tested:
<img width="3640" height="1580" alt="image" src="https://github.com/user-attachments/assets/0e52b6bd-3110-49e1-b3e9-58d95208d1a4" />
