### PR TITLE
update history UI after sending new request

### DIFF
--- a/app/[locale]/(protected)/_components/history-table/history-table-client.tsx
+++ b/app/[locale]/(protected)/_components/history-table/history-table-client.tsx
@@ -1,12 +1,16 @@
 "use client";
 
+import { useEffect } from "react";
+
 import type { HistoryEntry } from "@shared/types";
 
 import { HistoryHeader } from "@/app/[locale]/(protected)/_components/history-table/history-header";
 import { HistoryTableContent } from "@/app/[locale]/(protected)/_components/history-table/history-table-content";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import {
+  selectHistory,
   selectSelectedEntryId,
+  setHistory,
   setSelectedEntryId,
 } from "@/store/slices/history-slice";
 import { executeRequest } from "@/store/slices/request-slice";
@@ -15,16 +19,21 @@ import { selectResolvedRequest } from "@/utils/helpers/resolve-request";
 import { restoreRequest } from "@/utils/helpers/restore-request";
 
 export function HistoryTableClient({
-  entries,
+  initialEntries,
   labels,
   title,
 }: {
-  entries: HistoryEntry[];
+  initialEntries: HistoryEntry[];
   labels: { endpoint: string; method: string; status: string; time: string };
   title: string;
 }) {
   const dispatch = useAppDispatch();
+  const entries = useAppSelector(selectHistory);
   const selectedEntryId = useAppSelector(selectSelectedEntryId);
+
+  useEffect(() => {
+    dispatch(setHistory(initialEntries));
+  }, [initialEntries, dispatch]);
 
   const handleSelect = (entry: HistoryEntry) => {
     dispatch(setSelectedEntryId(entry.id));
@@ -40,6 +49,10 @@ export function HistoryTableClient({
     const resolvedOutput = selectResolvedRequest(store.getState());
     dispatch(executeRequest(resolvedOutput));
   };
+
+  if (entries.length === 0) {
+    return null;
+  }
 
   return (
     <div className="flex flex-col gap-4 p-6">

--- a/app/[locale]/(protected)/_components/history-table/history-table.tsx
+++ b/app/[locale]/(protected)/_components/history-table/history-table.tsx
@@ -48,7 +48,7 @@ export async function HistoryTable() {
 
   return (
     <HistoryTableClient
-      entries={entries}
+      initialEntries={entries}
       labels={{
         method: t("columns.method"),
         status: t("columns.status"),

--- a/store/slices/request-slice.ts
+++ b/store/slices/request-slice.ts
@@ -1,6 +1,12 @@
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-import type { ResolvedSelectorOutput, ResponseData } from "@shared/types";
+import type {
+  HistoryEntry,
+  ResolvedSelectorOutput,
+  ResponseData,
+} from "@shared/types";
+
+import { addEntry } from "@/store/slices/history-slice";
 
 interface RequestState {
   error: null | string;
@@ -13,53 +19,64 @@ const initialState: RequestState = {
   isLoading: false,
   error: null,
 };
-//
-// function calculateRequestSize(request: ResolvedRequest): number {
-//   const bodySize = request.body ? new Blob([request.body]).size : 0;
-//   const headersSize = new Blob(
-//     request.headers.map((header) => `${header.name}: ${header.value}\r\n`),
-//   ).size;
-//   const urlSize = new Blob([request.url]).size;
-//   return bodySize + headersSize + urlSize;
-// }
 
 export const executeRequest = createAsyncThunk<
   ResponseData,
   ResolvedSelectorOutput,
   { rejectValue: string }
->(
-  "request/execute",
-  async (resolvedOutput, { rejectWithValue, dispatch: _dispatch }) => {
-    if (!resolvedOutput.canGenerate || !resolvedOutput.resolved) {
-      return rejectWithValue(
-        resolvedOutput.issues.map((issue) => issue.type).join(", "),
-      );
-    }
+>("request/execute", async (resolvedOutput, { rejectWithValue, dispatch }) => {
+  if (!resolvedOutput.canGenerate || !resolvedOutput.resolved) {
+    return rejectWithValue(
+      resolvedOutput.issues.map((issue) => issue.type).join(", "),
+    );
+  }
 
-    const resolved = resolvedOutput.resolved;
+  const resolved = resolvedOutput.resolved;
 
-    try {
-      const resp = await fetch("/api/request", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          method: resolved.method,
-          url: resolved.url,
-          headers: Object.fromEntries(
-            resolved.headers.map((header) => [header.name, header.value]),
-          ),
-          body: resolved.body,
-        }),
-      });
+  try {
+    const resp = await fetch("/api/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        method: resolved.method,
+        url: resolved.url,
+        headers: Object.fromEntries(
+          resolved.headers.map((header) => [header.name, header.value]),
+        ),
+        body: resolved.body,
+      }),
+    });
 
-      return await resp.json();
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error";
-      return rejectWithValue(errorMessage);
-    }
-  },
-);
+    const data: ResponseData = await resp.json();
+
+    const newEntry: HistoryEntry = {
+      id: crypto.randomUUID(),
+      createdAt: data.meta.requestTimestamp,
+      request: {
+        method: resolved.method,
+        url: resolved.url,
+        headers: Object.fromEntries(
+          resolved.headers.map((h) => [h.name, h.value]),
+        ),
+        body: resolved.body ?? null,
+      },
+      response: {
+        status: data.status,
+        statusText: data.statusText,
+        error: null,
+        meta: data.meta,
+      },
+    };
+
+    dispatch(addEntry(newEntry));
+
+    return data;
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return rejectWithValue(errorMessage);
+  }
+});
 
 const requestSlice = createSlice({
   name: "request",


### PR DESCRIPTION
- Kept the history server-driven: `HistoryTable` still fetches data on the server with `getUserHistory`.

- Added dispatch of `setHistory` on mount in `HistoryTableClient` to populate Redux with server data.

- Changed `HistoryTableClient` to read entries from Redux (`selectHistory`) instead of props.

- Added dispatch of `addEntry(newEntry)` in request-slice after a successful request to update Redux and immediately re-render the history list.

Result

The history tab now updates instantly after sending a new request while remaining fully server-driven.