### PR TITLE
Fix body editor

### DIFF
--- a/__tests__/app/[locale]/(protected)/_components/body-editor/body-editor.test.tsx
+++ b/__tests__/app/[locale]/(protected)/_components/body-editor/body-editor.test.tsx
@@ -31,14 +31,13 @@ vi.mock("next-intl", () => ({
 vi.mock("@/shared/ui/json-viewer", () => ({
   JsonViewer: (props: {
     content: string;
-    mode: "json" | "text";
     onChange: (value: string) => void;
     placeholder?: string;
     readOnly?: boolean;
     showLineNumbers?: boolean;
   }) => (
     <textarea
-      aria-label={`json-viewer-${props.mode}`}
+      aria-label="json-viewer"
       onChange={(event) => props.onChange(event.currentTarget.value)}
       placeholder={props.placeholder}
       value={props.content}
@@ -95,16 +94,14 @@ describe("BodyEditor", () => {
 
     expect(screen.getByText("contentType")).toBeInTheDocument();
     expect(screen.getByDisplayValue("application/json")).toBeInTheDocument();
-
-    expect(screen.getByLabelText("json-viewer-json")).toBeInTheDocument();
-
+    expect(screen.getByLabelText("json-viewer")).toBeInTheDocument();
     expect(screen.getByText(/charactersCount/)).toBeInTheDocument();
   });
 
-  it("appends 'jsonDetected' marker when body is JSON-like in JSON mode", () => {
+  it("appends 'jsonDetected' marker when body is valid JSON", () => {
     isJsonLikeMock.mockReturnValue(true);
     hookState.contentType = "application/json";
-    hookState.body = "{}";
+    hookState.body = '{"a":1}';
     renderWithStore(<BodyEditor />);
 
     const counter = screen.getByText(/charactersCount/);
@@ -112,10 +109,10 @@ describe("BodyEditor", () => {
     expect(screen.getByText(/jsonDetected/)).toBeInTheDocument();
   });
 
-  it("does not append 'jsonDetected' when content is not JSON-like", () => {
+  it("does not append 'jsonDetected' when body is not JSON-like", () => {
     isJsonLikeMock.mockReturnValue(false);
     hookState.contentType = "application/json";
-    hookState.body = "not json";
+    hookState.body = "{ invalid json }";
     renderWithStore(<BodyEditor />);
 
     expect(screen.getByText(/charactersCount/)).toBeInTheDocument();
@@ -144,7 +141,7 @@ describe("BodyEditor", () => {
     expect(hookState.prettifyJson).toHaveBeenCalledTimes(N.ONE);
     expect(hookState.clearBody).toHaveBeenCalledTimes(N.ONE);
 
-    const viewer = screen.getByLabelText("json-viewer-json");
+    const viewer = screen.getByLabelText("json-viewer");
     await userEvent.clear(viewer);
     await userEvent.type(viewer, "new content");
     expect(hookState.handleBodyChange).toHaveBeenCalled();
@@ -153,7 +150,7 @@ describe("BodyEditor", () => {
   it("disables prettify when body is not JSON-like (even in JSON mode)", () => {
     isJsonLikeMock.mockReturnValue(false);
     hookState.contentType = "application/json";
-    hookState.body = "hello";
+    hookState.body = "{ invalid json }";
     renderWithStore(<BodyEditor />);
 
     const prettify = screen.getByTitle("prettifyButton");

--- a/__tests__/app/[locale]/(protected)/_components/body-editor/utils.test.ts
+++ b/__tests__/app/[locale]/(protected)/_components/body-editor/utils.test.ts
@@ -3,13 +3,15 @@ import { describe, expect, it } from "vitest";
 import { isJsonLike } from "@/app/[locale]/(protected)/_components/body-editor/utils";
 
 describe("isJsonLike", () => {
-  it("returns true for strings wrapped by {} or [] after trimming", () => {
+  it("returns true for valid JSON strings wrapped by {} or [] after trimming", () => {
     const truthySamples = [
       "{}",
       "[]",
       " { } ",
       "\n[1,2]\n",
       '\t{\n  "a": 1\n}\t',
+      '{"nested": {"key": "value"}}',
+      '[{"id": 1}, {"id": 2}]',
     ];
 
     for (const sample of truthySamples) {
@@ -32,23 +34,15 @@ describe("isJsonLike", () => {
       '"[1]"',
       " {] ",
       " [} ",
+      "{ trailing ]",
+      "[ leading }",
+      "{not: 'valid'}",
+      "[not, valid]",
+      "[][]]]]",
     ];
 
     for (const sample of falsySamples) {
       expect(isJsonLike(sample)).toBe(false);
-    }
-  });
-
-  it("does not validate JSON content; only first/last non-space characters matter", () => {
-    const cases: { expected: boolean; input: string }[] = [
-      { input: "{not: 'valid'}", expected: true },
-      { input: "[not, valid]", expected: true },
-      { input: "{ trailing ]", expected: false },
-      { input: "[ leading }", expected: false },
-    ];
-
-    for (const { input, expected } of cases) {
-      expect(isJsonLike(input)).toBe(expected);
     }
   });
 });

--- a/__tests__/shared/ui/json-viewer.test.tsx
+++ b/__tests__/shared/ui/json-viewer.test.tsx
@@ -3,15 +3,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-const GLOBALS = vi.hoisted(() => ({
-  CHAR_WIDTH_REM: 0.6,
-  LINE_HEIGHT_REM: 1.25,
-  PADDING_REM: 1,
-}));
-
-vi.mock("@/shared/globals", () => GLOBALS);
-
-import { JsonViewer } from "@/shared/ui";
+import { JsonViewer } from "@/shared/ui/json-viewer";
 
 describe("JsonViewer", () => {
   it("works in text mode without line numbers", () => {
@@ -23,7 +15,6 @@ describe("JsonViewer", () => {
     render(
       <JsonViewer
         content={initial}
-        mode="text"
         onChange={onChange}
         placeholder={placeholder}
         showLineNumbers={false}
@@ -36,11 +27,11 @@ describe("JsonViewer", () => {
     expect(onChange).toHaveBeenCalledWith(next);
   });
 
-  it("renders line numbers and syncs scroll", () => {
+  it("renders line numbers", () => {
     const lines = ["line-1", "line-2", "line-3"];
     const content = lines.join("\n");
 
-    render(<JsonViewer content={content} mode="json" showLineNumbers />);
+    render(<JsonViewer content={content} onChange={vi.fn()} showLineNumbers />);
 
     const monoRows = screen.getAllByText(/^\d+$/);
     const expectedCount = lines.length;
@@ -50,48 +41,5 @@ describe("JsonViewer", () => {
     const lastIndex = expectedCount - 1;
     expect(monoRows[FIRST_INDEX]).toHaveTextContent("1");
     expect(monoRows[lastIndex]).toHaveTextContent(String(expectedCount));
-
-    const PARENT_LEVELS_TO_GUTTER = 2;
-
-    function ascend(element: Element, levels: number): Element | null {
-      let current: Element | null = element;
-      for (let index = 0; index < levels; index += 1) {
-        current = current?.parentElement ?? null;
-        if (!current) {
-          return null;
-        }
-      }
-      return current;
-    }
-
-    function isHTMLDivElement(
-      element: Element | null,
-    ): element is HTMLDivElement {
-      return Boolean(element) && element instanceof HTMLDivElement;
-    }
-
-    const maybeGutter = ascend(monoRows[FIRST_INDEX], PARENT_LEVELS_TO_GUTTER);
-    if (!isHTMLDivElement(maybeGutter)) {
-      throw new Error("gutter container not found");
-    }
-    const gutter = maybeGutter;
-
-    const setter = vi.fn();
-    const getter = () => 0;
-    Object.defineProperty(gutter, "scrollTop", {
-      configurable: true,
-      get: getter,
-      set: setter,
-    });
-
-    const textarea = screen.getByRole("textbox");
-    const SCROLL_AMOUNT = 37;
-    Object.defineProperty(textarea, "scrollTop", {
-      value: SCROLL_AMOUNT,
-      writable: true,
-    });
-    fireEvent.scroll(textarea);
-
-    expect(setter).toHaveBeenCalledWith(SCROLL_AMOUNT);
   });
 });

--- a/app/[locale]/(protected)/_components/body-editor/body-editor-buttons.tsx
+++ b/app/[locale]/(protected)/_components/body-editor/body-editor-buttons.tsx
@@ -2,6 +2,8 @@
 
 import { useTranslations } from "next-intl";
 
+import { Trash2, Wand2 } from "lucide-react";
+
 interface BodyEditorButtonsProps {
   onClearBody: () => void;
   onPrettifyJson: () => void;
@@ -18,27 +20,13 @@ export function BodyEditorButtons({
   return (
     <div className="flex items-center gap-2">
       <button
-        className={`rounded p-1 transition-colors ${
-          showJsonControls
-            ? "cursor-pointer hover:bg-gray-100"
-            : "cursor-not-allowed text-gray-400"
-        }`}
+        className="cursor-pointer rounded p-1 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
         disabled={!showJsonControls}
-        onClick={showJsonControls ? onPrettifyJson : undefined}
+        onClick={onPrettifyJson}
         title={t("prettifyButton")}
         type="button"
       >
-        <svg
-          fill="none"
-          height="16"
-          stroke="currentColor"
-          strokeWidth="2"
-          viewBox="0 0 24 24"
-          width="16"
-        >
-          <path d="M12 20h9" />
-          <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
-        </svg>
+        <Wand2 className="h-4 w-4" />
       </button>
 
       <button
@@ -47,18 +35,7 @@ export function BodyEditorButtons({
         title={t("clearContent")}
         type="button"
       >
-        <svg
-          fill="none"
-          height="16"
-          stroke="currentColor"
-          strokeWidth="2"
-          viewBox="0 0 24 24"
-          width="16"
-        >
-          <path d="M3 6h18" />
-          <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
-          <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
-        </svg>
+        <Trash2 className="h-4 w-4" />
       </button>
     </div>
   );

--- a/app/[locale]/(protected)/_components/body-editor/body-editor.tsx
+++ b/app/[locale]/(protected)/_components/body-editor/body-editor.tsx
@@ -21,8 +21,8 @@ export function BodyEditor() {
     handleBodyChange,
   } = useBodyEditor();
 
-  const showJsonControls = isJsonLike(body);
   const isJsonMode = contentType === "application/json";
+  const jsonValid = isJsonMode ? isJsonLike(body) : false;
 
   return (
     <div className="space-y-4 p-6">
@@ -31,7 +31,7 @@ export function BodyEditor() {
         onClearBody={clearBody}
         onContentTypeChange={setContentType}
         onPrettifyJson={prettifyJson}
-        showJsonControls={showJsonControls}
+        showJsonControls={jsonValid}
       />
 
       <div className="space-y-2">
@@ -46,8 +46,8 @@ export function BodyEditor() {
         )}
 
         <JsonViewer
+          compactLineNumbers
           content={body}
-          mode={isJsonMode ? "json" : "text"}
           onChange={handleBodyChange}
           placeholder={t("placeholder")}
           readOnly={false}
@@ -56,7 +56,7 @@ export function BodyEditor() {
 
         <div className="text-xs text-gray-500">
           {t("charactersCount", { count: body.length })}
-          {isJsonMode && showJsonControls && ` • ${t("jsonDetected")}`}
+          {jsonValid && ` • ${t("jsonDetected")}`}
         </div>
       </div>
     </div>

--- a/app/[locale]/(protected)/_components/body-editor/utils.ts
+++ b/app/[locale]/(protected)/_components/body-editor/utils.ts
@@ -1,7 +1,20 @@
 export const isJsonLike = (text: string): boolean => {
   const trimmed = text.trim();
-  return (
-    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
-    (trimmed.startsWith("[") && trimmed.endsWith("]"))
-  );
+  if (!trimmed) {
+    return false;
+  }
+
+  if (
+    !(trimmed.startsWith("{") && trimmed.endsWith("}")) &&
+    !(trimmed.startsWith("[") && trimmed.endsWith("]"))
+  ) {
+    return false;
+  }
+
+  try {
+    JSON.parse(trimmed);
+    return true;
+  } catch {
+    return false;
+  }
 };

--- a/app/[locale]/(protected)/_components/codegen/codegen-panel.tsx
+++ b/app/[locale]/(protected)/_components/codegen/codegen-panel.tsx
@@ -59,7 +59,6 @@ export function CodegenPanel() {
       <JsonViewer
         className="text-text-secondary h-[420px]"
         content={snippet || t("hints")}
-        mode="json"
         readOnly
         showLineNumbers
       />

--- a/shared/ui/json-viewer.tsx
+++ b/shared/ui/json-viewer.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { CHAR_WIDTH_REM, LINE_HEIGHT_REM, PADDING_REM } from "@/shared/globals";
 
 interface JsonViewerProps {
   className?: string;
+  compactLineNumbers?: boolean;
   content: string;
-  mode?: "json" | "text";
   onChange?: (value: string) => void;
   placeholder?: string;
   readOnly?: boolean;
@@ -21,20 +21,21 @@ export function JsonViewer({
   placeholder = "",
   className = "",
   onChange,
-  mode = "json",
+  compactLineNumbers = false,
 }: JsonViewerProps) {
   const textareaReference = useRef<HTMLTextAreaElement>(null);
   const lineNumbersReference = useRef<HTMLDivElement>(null);
 
-  const lines = content.split("\n");
-  const totalLines = lines.length;
-  const lineNumberWidth = Math.max(2, String(totalLines).length);
+  const COMPACT_SCALE = 0.7;
+  const COMPACT_PADDING_SCALE = 0.5;
+
+  const lines = useMemo(() => content.split("\n"), [content]);
+  const lineNumberWidth = Math.max(2, String(lines.length).length);
 
   useEffect(() => {
     const textarea = textareaReference.current;
     const lineNumbers = lineNumbersReference.current;
-
-    if (!textarea || !lineNumbers || !showLineNumbers) {
+    if (!textarea || !lineNumbers) {
       return;
     }
 
@@ -44,53 +45,43 @@ export function JsonViewer({
 
     textarea.addEventListener("scroll", handleScroll);
     return () => textarea.removeEventListener("scroll", handleScroll);
-  }, [showLineNumbers]);
+  }, []);
 
-  if (mode === "text" || !showLineNumbers) {
-    return (
-      <textarea
-        className={`h-64 w-full resize-y rounded border border-gray-300 p-3 font-mono text-sm leading-5 focus:border-blue-500 focus:outline-none ${
-          readOnly ? "cursor-default bg-gray-50" : ""
-        } ${className}`}
-        onChange={
-          readOnly ? undefined : (event) => onChange?.(event.target.value)
-        }
-        placeholder={placeholder}
-        readOnly={readOnly}
-        ref={textareaReference}
-        spellCheck={false}
-        value={content}
-      />
-    );
-  }
+  const charWidth = compactLineNumbers
+    ? CHAR_WIDTH_REM * COMPACT_SCALE
+    : CHAR_WIDTH_REM;
+  const padding = compactLineNumbers
+    ? PADDING_REM * COMPACT_PADDING_SCALE
+    : PADDING_REM;
+
+  const widthRem = `calc(${lineNumberWidth} * ${charWidth}rem + ${padding}rem)`;
 
   return (
     <div
-      className={`flex h-64 resize-y overflow-hidden rounded border border-gray-300 bg-white ${className}`}
+      className={`flex h-64 resize-y overflow-hidden rounded border border-gray-300 bg-white font-mono text-sm ${className}`}
     >
       <div
-        className="overflow-hidden bg-gray-50 text-right text-xs text-gray-500 select-none"
+        className={`overflow-hidden bg-gray-50 text-right text-xs text-gray-500 select-none ${
+          showLineNumbers ? "visible opacity-100" : "invisible opacity-0"
+        } transition-opacity`}
         ref={lineNumbersReference}
         style={{
-          width: `calc(${lineNumberWidth} * ${CHAR_WIDTH_REM}rem + ${PADDING_REM}rem)`,
+          width: widthRem,
           lineHeight: `${LINE_HEIGHT_REM}rem`,
         }}
       >
-        <div className="py-3 pr-2">
-          {lines.map((_, index) => (
-            <div
-              className="font-mono"
-              key={index}
-              style={{ height: `${LINE_HEIGHT_REM}rem` }}
-            >
-              {index + 1}
-            </div>
-          ))}
+        <div className="py-3 pr-1">
+          {showLineNumbers &&
+            lines.map((_, index) => (
+              <div key={index} style={{ height: `${LINE_HEIGHT_REM}rem` }}>
+                {index + 1}
+              </div>
+            ))}
         </div>
       </div>
 
       <textarea
-        className={`h-full flex-1 resize-none border-none p-3 font-mono text-sm leading-5 focus:outline-none ${
+        className={`h-full flex-1 resize-none border-none pt-3 pr-3 pb-3 pl-2 leading-5 focus:outline-none ${
           readOnly ? "cursor-default bg-gray-50" : ""
         }`}
         onChange={
@@ -100,6 +91,7 @@ export function JsonViewer({
         readOnly={readOnly}
         ref={textareaReference}
         spellCheck={false}
+        style={{ lineHeight: `${LINE_HEIGHT_REM}rem` }}
         value={content}
       />
     </div>


### PR DESCRIPTION
# Summary of Changes

## **BodyEditor**
- Added `compactLineNumbers` and reduced text indentation in `JsonViewer` for better readability.
- Now detects valid JSON by actually parsing it (`JSON.parse`) instead of only checking first/last characters.
- Passes `isJsonLike` result to conditionally enable **Prettify** button and display `jsonDetected` marker only when body is valid JSON.

## **BodyEditorButtons**
- Disabled **Prettify** button when body is not valid JSON (restoring previous behavior).

## **isJsonLike**
- Rewritten to:
  - Trim input.
  - Require both matching braces/brackets **and** successful `JSON.parse`.
  - Return `false` for malformed or invalid JSON (e.g., `['wew': 'wefew']`).

## **Tests**
- Updated `BodyEditor` tests:
  - Expect `jsonDetected` marker only for valid JSON.
  - Expect **Prettify** button to be disabled when body is not valid JSON.