### PR TITLE
Updating the AuthProvider to establish the session cookie before fetching the history

### DIFF
--- a/__tests__/app/[locale]/(protected)/_components/history-table/history-table-client.test.tsx
+++ b/__tests__/app/[locale]/(protected)/_components/history-table/history-table-client.test.tsx
@@ -129,6 +129,7 @@ describe("HistoryTableClient", () => {
 
     render(
       <HistoryTableClient
+        detailsLabel="Details"
         entries={ENTRIES}
         labels={{
           endpoint: "Endpoint",

--- a/app/[locale]/(protected)/_components/history-table/history-table-client.tsx
+++ b/app/[locale]/(protected)/_components/history-table/history-table-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useTranslations } from "next-intl";
 
 import RequestDetailsModal from "@app/[locale]/(protected)/_components/history-table/request-details-modal";
 import type { HistoryEntry } from "@shared/types";
@@ -21,8 +20,10 @@ import { restoreRequest } from "@/utils/helpers/restore-request";
 export function HistoryTableClient({
   entries,
   labels,
+  detailsLabel,
   title,
 }: {
+  detailsLabel: string;
   entries: HistoryEntry[];
   labels: { endpoint: string; method: string; status: string; time: string };
   title: string;
@@ -32,8 +33,6 @@ export function HistoryTableClient({
 
   const [open, setOpen] = useState(false);
   const [modalEntry, setModalEntry] = useState<HistoryEntry | null>(null);
-
-  const t = useTranslations("history-table");
 
   const handleSelect = (entry: HistoryEntry) => {
     dispatch(setSelectedEntryId(entry.id));
@@ -63,7 +62,7 @@ export function HistoryTableClient({
         title={title}
       />
       <HistoryTableContent
-        detailsLabel={t("columns.details")}
+        detailsLabel={detailsLabel}
         entries={entries}
         labels={labels}
         onSelect={handleSelect}

--- a/app/[locale]/(protected)/_components/history-table/history-table.tsx
+++ b/app/[locale]/(protected)/_components/history-table/history-table.tsx
@@ -48,6 +48,7 @@ export async function HistoryTable() {
 
   return (
     <HistoryTableClient
+      detailsLabel={t("columns.details")}
       entries={entries}
       labels={{
         method: t("columns.method"),

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -35,13 +35,13 @@ export default async function LocaleLayout({
   return (
     <html data-scroll-behavior="smooth" suppressHydrationWarning>
       <body className="bg-bg-primary text-base">
-        <ReduxProvider>
-          <NextIntlClientProvider locale={locale} messages={messages}>
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <ReduxProvider>
             <Header />
             {children}
             <Footer />
-          </NextIntlClientProvider>
-        </ReduxProvider>
+          </ReduxProvider>
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -2,23 +2,39 @@
 
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
+import { useLocale } from "next-intl";
 
 import { getIdToken, onAuthStateChanged } from "firebase/auth";
 
+import { serverLogin } from "@/shared/auth/auth";
 import { auth } from "@/shared/lib/firebase/client";
 import { setHistory } from "@/store/slices/history-slice";
 
 export function AuthProvider() {
   const dispatch = useDispatch();
+  const locale = useLocale();
 
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, async (user) => {
       try {
+        if (!user) {
+          dispatch(setHistory([]));
+          return;
+        }
         const token = user ? await getIdToken(user, false) : null;
+        if (!token) {
+          dispatch(setHistory([]));
+          return;
+        }
+
+        await serverLogin(locale, token);
+
+        const controller = new AbortController();
+
         const resp = await fetch("/api/history", {
           credentials: "include",
           cache: "no-store",
-          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          signal: controller.signal,
         });
         if (!resp.ok) {
           dispatch(setHistory([]));
@@ -32,7 +48,7 @@ export function AuthProvider() {
     });
 
     return () => unsub();
-  }, [dispatch]);
+  }, [dispatch, locale]);
 
   return null;
 }


### PR DESCRIPTION
**What**
- Moved from sending Firebase `Bearer` token on every request to using a session via ```serverLogin(locale, token)```.
- ```/api/history``` is now fetched with session cookies instead of explicit Authorization header.

**Details of Changes**
- **AuthProvider**:
  - Subscribes to `onAuthStateChanged`.
  - Gets `idToken` from Firebase user.
  - Calls `serverLogin(locale, token)` once to establish a session.
  - Uses `AbortController` to cancel fetch if component unmounts.
  - Fetches `/api/history` with `credentials: "include"`, no `Authorization` header.
  - Dispatches `setHistory(items)` or `[]` on errors/logouts.

