### PR TITLE
Implement history refresh functionality

### DIFF
--- a/app/[locale]/(protected)/_components/history-table/history-table-client.tsx
+++ b/app/[locale]/(protected)/_components/history-table/history-table-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import RequestDetailsModal from "@app/[locale]/(protected)/_components/history-table/request-details-modal";
 import type { HistoryEntry } from "@shared/types";
@@ -18,7 +18,7 @@ import { selectResolvedRequest } from "@/utils/helpers/resolve-request";
 import { restoreRequest } from "@/utils/helpers/restore-request";
 
 export function HistoryTableClient({
-  entries,
+  entries: initialEntries,
   labels,
   detailsLabel,
   title,
@@ -30,9 +30,22 @@ export function HistoryTableClient({
 }) {
   const dispatch = useAppDispatch();
   const selectedEntryId = useAppSelector(selectSelectedEntryId);
-
+  const [entries, setEntries] = useState(initialEntries);
   const [open, setOpen] = useState(false);
   const [modalEntry, setModalEntry] = useState<HistoryEntry | null>(null);
+
+  useEffect(() => {
+    const handleRefreshHistory = (event: Event) => {
+      if (event instanceof CustomEvent) {
+        setEntries(event.detail);
+      }
+    };
+
+    window.addEventListener("refresh-history", handleRefreshHistory);
+    return () => {
+      window.removeEventListener("refresh-history", handleRefreshHistory);
+    };
+  }, []);
 
   const handleSelect = (entry: HistoryEntry) => {
     dispatch(setSelectedEntryId(entry.id));

--- a/store/slices/request-slice.ts
+++ b/store/slices/request-slice.ts
@@ -18,47 +18,62 @@ export const executeRequest = createAsyncThunk<
   ResponseData,
   ResolvedSelectorOutput,
   { rejectValue: string }
->(
-  "request/execute",
-  async (resolvedOutput, { rejectWithValue, dispatch: _dispatch }) => {
-    if (!resolvedOutput.canGenerate || !resolvedOutput.resolved) {
-      return rejectWithValue(
-        resolvedOutput.issues.map((issue) => issue.type).join(", "),
-      );
-    }
+>("request/execute", async (resolvedOutput, { rejectWithValue }) => {
+  if (!resolvedOutput.canGenerate || !resolvedOutput.resolved) {
+    return rejectWithValue(
+      resolvedOutput.issues.map((issue) => issue.type).join(", "),
+    );
+  }
 
-    const resolved = resolvedOutput.resolved;
+  const resolved = resolvedOutput.resolved;
+
+  try {
+    const resp = await fetch("/api/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        method: resolved.method,
+        url: resolved.url,
+        headers: Object.fromEntries(
+          resolved.headers.map((header) => [header.name, header.value]),
+        ),
+        body: resolved.body,
+      }),
+      credentials: "include",
+    });
 
     try {
-      const resp = await fetch("/api/request", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          method: resolved.method,
-          url: resolved.url,
-          headers: Object.fromEntries(
-            resolved.headers.map((header) => [header.name, header.value]),
-          ),
-          body: resolved.body,
-        }),
-        credentials: "include",
-      });
+      const text = await resp.text();
 
       try {
-        const text = await resp.text();
-        return text
-          ? JSON.parse(text)
-          : { status: 200, statusText: resp.statusText };
+        const historyResp = await fetch("/api/history", {
+          credentials: "include",
+          cache: "no-store",
+        });
+        if (historyResp.ok) {
+          const { items } = await historyResp.json();
+          if (typeof window !== "undefined") {
+            window.dispatchEvent(
+              new CustomEvent("refresh-history", { detail: items }),
+            );
+          }
+        }
       } catch {
-        return { status: 200, statusText: resp.statusText };
+        console.warn("Failed to refresh history after request");
       }
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error";
-      return rejectWithValue(errorMessage);
+
+      return text
+        ? JSON.parse(text)
+        : { status: 200, statusText: resp.statusText };
+    } catch {
+      return { status: 200, statusText: resp.statusText };
     }
-  },
-);
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return rejectWithValue(errorMessage);
+  }
+});
 
 const requestSlice = createSlice({
   name: "request",


### PR DESCRIPTION
# Summary

- **HistoryTableClient** was updated to manage `entries` via local state initialized from SSR props.
- A `refresh-history` event listener was added to update the table when new data is fetched from the server.
- **executeRequest** was updated to fetch the full request history (`/api/history`) after a successful request and dispatch a `refresh-history` event with the updated list.

## Why

This change ensures that:
- Request history is still fully aggregated and sorted on the server.
- The client does not build or modify the history manually — it simply re-renders the server-provided list.
- The history table automatically refreshes after sending a request, without requiring a full page reload, while remaining fully compliant with the requirement that all history and analytics are server-side generated.